### PR TITLE
fix(ui): mobile header background + hero title sizing + close button spacing

### DIFF
--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -99,8 +99,8 @@ const isActiveRoute = (route: string) => {
                     <div class="flex flex-col h-full min-h-0">
                         <!-- Header simplifié -->
                         <div
-                            class="bg-gradient-to-r from-primary-600 to-secondary-600 p-5 pt-[env(safe-area-inset-top)]">
-                            <div class="flex items-center justify-between">
+                            class="bg-gradient-to-r from-primary-600 to-secondary-600 p-5 pt-[max(env(safe-area-inset-top),1.25rem)] pl-[max(env(safe-area-inset-left),1.25rem)] pr-[max(env(safe-area-inset-right),1.25rem)]">
+                            <div class="flex items-center justify-between overflow-visible">
                                 <div>
                                     <span id="mobile-menu-title" class="text-xl font-black text-white"
                                         >{EVENT_DATA.event.shortName}</span
@@ -112,7 +112,7 @@ const isActiveRoute = (route: string) => {
                                 </div>
                                 <label
                                     for="nav-trigger"
-                                    class="w-14 h-14 flex items-center justify-center rounded-full bg-white/10 hover:bg-white/20 active:bg-white/30 transition-all duration-200 cursor-pointer"
+                                    class="w-14 h-14 flex items-center justify-center rounded-full bg-white/10 hover:bg-white/20 active:bg-white/30 transition-all duration-200 cursor-pointer shrink-0"
                                     aria-label="Fermer le menu">
                                     <svg
                                         class="w-6 h-6 text-white"

--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -64,7 +64,7 @@ import { EVENT_DATA } from '../../config'
             <div class="space-y-3 sm:space-y-4 scroll-animate">
                 <h1
                     id="event-title"
-                    class="text-7xl lg:text-8xl xl:text-9xl font-black text-white mb-3 sm:mb-4 tracking-tight leading-tight">
+                    class="text-6xl sm:text-7xl lg:text-8xl xl:text-9xl font-black text-white mb-3 sm:mb-4 tracking-tight leading-tight">
                     <span class="inline-block animate-slide-down" style="animation-delay: 0.2s;"
                         >{EVENT_DATA.event.shortName}</span
                     >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,22 +11,22 @@
 
 /* Assurer la visibilité du header sur mobile */
 @media (max-width: 767px) {
+    /* Le header doit être OPAQUE sur mobile */
     #site-header {
-        /* Force un arrière-plan minimum sur mobile pour garantir la visibilité */
-        background-color: rgba(0, 0, 0, 0.1) !important;
-        backdrop-filter: blur(8px) !important;
-        -webkit-backdrop-filter: blur(8px) !important;
+        background-color: #ffffff !important;
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
     }
 
+    /* Même en mode "transparent", on garde un fond blanc sur mobile */
     #site-header[data-transparent='true'] {
-        /* Même en mode transparent, garder un arrière-plan léger sur mobile */
-        background-color: rgba(0, 0, 0, 0.2) !important;
+        background-color: #ffffff !important;
     }
 
-    /* Améliorer la lisibilité du logo sur mobile */
+    /* Retirer le shadow forcé pour un rendu net */
     #site-header span,
     #site-header a {
-        text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5) !important;
+        text-shadow: none !important;
     }
 }
 


### PR DESCRIPTION
This PR fixes multiple mobile UI issues:

- Header background on mobile is now opaque (white), removing semi-transparent overlay and blur enforcing transparency
- Hero title size reduced on mobile to prevent clipping; adjusted to `text-6xl` for better balance
- Mobile menu close button spacing: added safe-area-aware paddings and prevented clipping/shrinking

Build status: local `npm run build` passes.

Please review. Once checks pass, I will proceed to merge.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author