### PR TITLE
fix: corriger l'authentification Firebase CLI dans le workflow de déploiement

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -59,8 +59,11 @@ jobs:
             - name: Setup Firebase CLI
               run: |
                   npm install -g firebase-tools
+                  # Create service account file
                   echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT_TECHWORK_2026 }}' > ${HOME}/firebase-service-account.json
-                  export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/firebase-service-account.json
+                  chmod 600 ${HOME}/firebase-service-account.json
+                  # Set environment variable for Firebase CLI
+                  echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/firebase-service-account.json" >> $GITHUB_ENV
 
             - name: Create Functions environment file
               run: |
@@ -93,4 +96,4 @@ jobs:
                   FIREBASE_MEASUREMENT_ID: '${{ secrets.FIREBASE_MEASUREMENT_ID }}'
                   OPENPLANNER_URL: ${{ secrets.OPENPLANNER_URL }}
                   # Firebase service account for Firebase CLI (used by Task)
-                  GOOGLE_APPLICATION_CREDENTIALS: ${HOME}/firebase-service-account.json
+                  GOOGLE_APPLICATION_CREDENTIALS: /home/runner/firebase-service-account.json

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1069,6 +1069,12 @@ tasks:
                   exit 1
                 fi
 
+                # Ensure GOOGLE_APPLICATION_CREDENTIALS is set if provided
+                if [ -n "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+                  export GOOGLE_APPLICATION_CREDENTIALS
+                  echo "✅ Using service account: $GOOGLE_APPLICATION_CREDENTIALS"
+                fi
+
                 # Switch to the correct Firebase project
                 firebase use "techwork-{{.YEAR}}"
 


### PR DESCRIPTION
## Problème

Le workflow de déploiement échouait avec l'erreur :
```
Error: Failed to authenticate, have you run firebase login?
```

## Solution

- Ajout de `GOOGLE_APPLICATION_CREDENTIALS` dans `GITHUB_ENV` pour le rendre disponible dans tous les steps suivants
- Export explicite de la variable dans Taskfile avant l'exécution de `firebase deploy`
- S'assurer que Firebase CLI utilise correctement le service account

## Fichiers modifiés

- `.github/workflows/deploy-on-merge.yml` : Configuration de l'authentification Firebase
- `Taskfile.yml` : Export explicite de `GOOGLE_APPLICATION_CREDENTIALS` avant le déploiement

## Test

Le workflow devrait maintenant pouvoir s'authentifier correctement avec Firebase CLI et déployer le site sans erreur.