### PR TITLE
Accueil adaptatif par phase + mode live jour J

### DIFF
--- a/src/components/PhaseController.astro
+++ b/src/components/PhaseController.astro
@@ -1,0 +1,111 @@
+---
+// Pilote l'accueil adaptative : calcule la "phase" de l'événement à partir de
+// l'heure du navigateur (override possible via ?now=) et la pose sur <html>
+// AVANT le paint pour éviter tout flash (FOUC).
+//
+// Phases :
+//   default  -> avant preEventStart            (accueil marketing, fallback no-JS/SEO)
+//   preevent -> preEventStart .. liveStart      (comment venir + programme, billets masqués)
+//   live     -> liveStart .. liveEnd            (sessions en cours / à venir, favoris, feedback)
+//   post     -> après liveEnd                   (merci + programme)
+//
+// Les bornes liveStart / liveEnd sont DÉRIVÉES du programme (1ʳᵉ session avec
+// orateur -> dernière fin), pas codées en dur. preEventStart est une ancre de config.
+import { EVENT_DATA, LIVE_DATA } from '../config'
+import { getScheduleData } from '../data/conference-hall'
+
+const { sessions } = getScheduleData()
+
+const startTimes = sessions
+    .map((s) => s.dateStart)
+    .filter((d): d is string => !!d)
+    .sort()
+const endTimes = sessions
+    .map((s) => s.dateEnd)
+    .filter((d): d is string => !!d)
+    .sort()
+
+const liveStart = startTimes.length ? startTimes[0] : null
+const liveEnd = endTimes.length ? endTimes[endTimes.length - 1] : null
+const preEventStart = LIVE_DATA.preEventStart
+const eventDayIso = EVENT_DATA.event.date.iso
+---
+
+<script is:inline define:vars={{ preEventStart, liveStart, liveEnd, eventDayIso }}>
+    ;(function () {
+        function getNow() {
+            try {
+                var p = new URLSearchParams(window.location.search).get('now')
+                if (p) {
+                    var d = new Date(p)
+                    if (!isNaN(d.getTime())) return d
+                }
+            } catch (e) {}
+            return new Date()
+        }
+
+        function computePhase() {
+            var now = getNow()
+            // Ancres parsées comme heures locales naïves (cohérent avec le programme).
+            var pre = new Date(preEventStart)
+            var ls = liveStart ? new Date(liveStart) : null
+            var le = liveEnd ? new Date(liveEnd) : null
+
+            var phase = 'default'
+            if (le && now >= le) phase = 'post'
+            else if (ls && le && now >= ls && now < le) phase = 'live'
+            else if (now >= pre) phase = 'preevent'
+
+            var root = document.documentElement
+            root.setAttribute('data-phase', phase)
+
+            // Jour J : active la variante "C'est aujourd'hui" en phase preevent.
+            var isEventDay = false
+            try {
+                var y = now.getFullYear()
+                var m = ('0' + (now.getMonth() + 1)).slice(-2)
+                var dd = ('0' + now.getDate()).slice(-2)
+                isEventDay = y + '-' + m + '-' + dd === eventDayIso
+            } catch (e) {}
+            root.setAttribute('data-eventday', isEventDay ? 'true' : 'false')
+        }
+
+        computePhase()
+        // Le router Astro (ClientRouter) conserve <html> entre les navigations ;
+        // on recalcule par sécurité après chaque swap.
+        document.addEventListener('astro:after-swap', computePhase)
+        // Recalcul périodique : si la page reste ouverte et franchit une bascule
+        // (1ʳᵉ conf, fin de l'événement…), la phase change sans rechargement.
+        setInterval(computePhase, 30000)
+    })()
+</script>
+
+<style is:global>
+    /* Fallback sans JS : seul le contenu "default" (accueil marketing) est visible. */
+    html:not([data-phase]) [data-when]:not([data-when~='default']) {
+        display: none !important;
+    }
+    /* Visibilité par phase : on masque tout [data-when] qui ne cible pas la phase courante. */
+    html[data-phase='default'] [data-when]:not([data-when~='default']) {
+        display: none !important;
+    }
+    html[data-phase='preevent'] [data-when]:not([data-when~='preevent']) {
+        display: none !important;
+    }
+    html[data-phase='live'] [data-when]:not([data-when~='live']) {
+        display: none !important;
+    }
+    html[data-phase='post'] [data-when]:not([data-when~='post']) {
+        display: none !important;
+    }
+    /* CTA billets/CFP globaux : masqués dès qu'on quitte la phase marketing. */
+    html[data-phase='preevent'] [data-phase-hide~='preevent'],
+    html[data-phase='live'] [data-phase-hide~='live'],
+    html[data-phase='post'] [data-phase-hide~='post'] {
+        display: none !important;
+    }
+    /* Variante "jour J" : visible uniquement le jour de l'événement. */
+    html:not([data-eventday='true']) [data-eventday-only] {
+        display: none !important;
+    }
+</style>

--- a/src/components/cta/CTASection.astro
+++ b/src/components/cta/CTASection.astro
@@ -18,7 +18,9 @@ const isTicketingOpen = EVENT_DATA.event.ticketingOpen
 const TARGET_URL = isTicketingOpen ? TICKETING_BASE_URL : '/billetterie-fermee'
 ---
 
-<section class="py-12 sm:py-16 lg:py-20 bg-gradient-to-r from-primary-50 to-secondary-50">
+<section
+    class="py-12 sm:py-16 lg:py-20 bg-gradient-to-r from-primary-50 to-secondary-50"
+    data-phase-hide="preevent live post">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
         <h2 class="text-2xl sm:text-3xl lg:text-4xl font-black text-gray-900 mb-4">{title}</h2>
         <p class="text-gray-700 mb-6 max-w-2xl mx-auto">{description}</p>

--- a/src/components/cta/PrimaryCTA.astro
+++ b/src/components/cta/PrimaryCTA.astro
@@ -11,6 +11,7 @@ const TARGET_URL = isTicketingOpen ? TICKETING_BASE_URL : '/billetterie-fermee'
 <a
     href={TARGET_URL}
     class="btn btn-primary inline-flex items-center gap-2 hover-lift"
+    data-phase-hide="preevent live post"
     data-cta
     data-placement="header"
     data-base-href={TARGET_URL}

--- a/src/components/cta/StickyCTA.astro
+++ b/src/components/cta/StickyCTA.astro
@@ -8,7 +8,10 @@ const CTA_LABEL = labelFor(EXPERIMENTS.ctaLabelVariant)
 const TARGET_URL = isTicketingOpen ? TICKETING_BASE_URL : '/billetterie-fermee'
 ---
 
-<div id="sticky-cta" class="fixed inset-x-0 bottom-4 z-[9998] px-4 pointer-events-none hidden">
+<div
+    id="sticky-cta"
+    class="fixed inset-x-0 bottom-4 z-[9998] px-4 pointer-events-none hidden"
+    data-phase-hide="preevent live post">
     <div class="max-w-6xl mx-auto pointer-events-auto">
         <a
             href={TARGET_URL}

--- a/src/components/home/HomeLiveSessions.astro
+++ b/src/components/home/HomeLiveSessions.astro
@@ -153,7 +153,12 @@ const eventHashtag = '#QueLeLamaSoitAvecNous'
 ---
 
 <section class="py-10 sm:py-14" data-feedback-window={feedbackWindow}>
-    <script type="application/json" id="live-data" set:html={JSON.stringify(items)} is:inline />
+    <script
+        type="application/json"
+        id="live-data"
+        set:html={JSON.stringify(items).replace(/</g, '\\u003c')}
+        is:inline
+    />
 
     <div class="max-w-3xl mx-auto px-5">
         {/* Onglets */}
@@ -591,7 +596,7 @@ const eventHashtag = '#QueLeLamaSoitAvecNous'
             'Aucun favori pour l’instant. Touchez ☆ sur une session pour l’ajouter ici.'
         )
 
-        setCount('now', nowCards.length)
+        setCount('now', nowCards.length + feedbackCards.length)
         setCount('next', nextCards.length)
         setCount('all', allCards.length)
         setCount('fav', favTimes.length)

--- a/src/components/home/HomeLiveSessions.astro
+++ b/src/components/home/HomeLiveSessions.astro
@@ -169,6 +169,9 @@ const eventHashtag = '#QueLeLamaSoitAvecNous'
             <button type="button" class="live-tab" data-tab="next" role="tab" aria-selected="false">
                 ⏭️ À venir <span class="live-tab-count" data-count="next"></span>
             </button>
+            <button type="button" class="live-tab" data-tab="past" role="tab" aria-selected="false">
+                🏁 Terminées <span class="live-tab-count" data-count="past"></span>
+            </button>
             <button type="button" class="live-tab" data-tab="all" role="tab" aria-selected="false">
                 📅 Tous <span class="live-tab-count" data-count="all"></span>
             </button>
@@ -181,6 +184,7 @@ const eventHashtag = '#QueLeLamaSoitAvecNous'
         {/* Panneaux */}
         <div id="tab-now" class="live-panel" role="tabpanel"></div>
         <div id="tab-next" class="live-panel" role="tabpanel" hidden></div>
+        <div id="tab-past" class="live-panel" role="tabpanel" hidden></div>
         <div id="tab-all" class="live-panel" role="tabpanel" hidden></div>
         <div id="tab-fav" class="live-panel" role="tabpanel" hidden></div>
 
@@ -510,10 +514,6 @@ const eventHashtag = '#QueLeLamaSoitAvecNous'
         if (cards.length === 0) return `<p class="text-center text-gray-500 py-8">${emptyMsg}</p>`
         return `<div class="grid gap-3">${cards.join('')}</div>`
     }
-    function blockHtml(title: string, cards: string[]): string {
-        if (cards.length === 0) return ''
-        return `<div class="mb-6"><h3 class="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">${title}</h3><div class="grid gap-3">${cards.join('')}</div></div>`
-    }
 
     const TAB_KEY = 'techwork-live-tab'
     let activeTab = 'now'
@@ -523,7 +523,7 @@ const eventHashtag = '#QueLeLamaSoitAvecNous'
         try {
             sessionStorage.setItem(TAB_KEY, tab)
         } catch (e) {}
-        ;['now', 'next', 'all', 'fav', 'info'].forEach((t) => {
+        ;['now', 'next', 'past', 'all', 'fav', 'info'].forEach((t) => {
             const panel = document.getElementById('tab-' + t)
             if (panel) (panel as HTMLElement).hidden = t !== tab
         })
@@ -548,7 +548,6 @@ const eventHashtag = '#QueLeLamaSoitAvecNous'
         } catch (e) {
             return
         }
-        const feedbackWindowMs = parseInt(root.getAttribute('data-feedback-window') || '20', 10) * 60000
         const nowMs = getNow().getTime()
         const favs = getFavs()
 
@@ -556,26 +555,23 @@ const eventHashtag = '#QueLeLamaSoitAvecNous'
             .map((d) => ({ it: d, startT: new Date(d.start).getTime(), endT: new Date(d.end).getTime() }))
             .sort((a, b) => a.startT - b.startT)
 
-        // Onglet "En ce moment" : feedback (sessions tout juste finies) + sessions en cours.
-        const feedbackCards = withTimes
-            .filter((x) => x.it.feedbackUrl && x.endT <= nowMs && nowMs - x.endT <= feedbackWindowMs)
-            .sort((a, b) => b.endT - a.endT)
-            .map((x) => buildCard(x.it, favs, { feedback: true }))
+        // Onglet "En ce moment" : uniquement les sessions en cours (le feedback des
+        // sessions finies vit dans l'onglet "Terminées" -> pas de doublon).
         const nowCards = withTimes
             .filter((x) => x.startT <= nowMs && nowMs < x.endT)
             .map((x) => buildCard(x.it, favs, { statusHtml: statusBadge(x.startT, x.endT, nowMs) }))
-        const nowPanel =
-            blockHtml('💬 Donnez votre avis', feedbackCards) +
-            (nowCards.length
-                ? blockHtml('🔴 En cours', nowCards)
-                : feedbackCards.length
-                  ? ''
-                  : listHtml([], 'Aucune session en cours pour le moment.'))
 
-        // Onglet "Plus tard" : tout ce qui démarre après maintenant.
+        // Onglet "À venir" : tout ce qui démarre après maintenant.
         const nextCards = withTimes
             .filter((x) => x.startT > nowMs)
             .map((x) => buildCard(x.it, favs, { statusHtml: statusBadge(x.startT, x.endT, nowMs) }))
+
+        // Onglet "Terminées" : talks/keynotes passés (avec lien + avis), plus récent
+        // d'abord. On exclut les entrées sans page (pauses, déjeuner…).
+        const pastCards = withTimes
+            .filter((x) => x.endT <= nowMs && x.it.sessionUrl)
+            .sort((a, b) => b.endT - a.endT)
+            .map((x) => buildCard(x.it, favs, { feedback: true, statusHtml: statusBadge(x.startT, x.endT, nowMs) }))
 
         // Onglet "Tout le programme" : toute la journée, avec statut.
         const allCards = withTimes.map((x) =>
@@ -588,15 +584,17 @@ const eventHashtag = '#QueLeLamaSoitAvecNous'
             buildCard(x.it, favs, { statusHtml: statusBadge(x.startT, x.endT, nowMs) })
         )
 
-        document.getElementById('tab-now')!.innerHTML = nowPanel
+        document.getElementById('tab-now')!.innerHTML = listHtml(nowCards, 'Aucune session en cours pour le moment.')
         document.getElementById('tab-next')!.innerHTML = listHtml(nextCards, 'Plus de sessions à venir aujourd’hui.')
+        document.getElementById('tab-past')!.innerHTML = listHtml(pastCards, 'Aucune session terminée pour l’instant.')
         document.getElementById('tab-all')!.innerHTML = listHtml(allCards, 'Programme indisponible.')
         document.getElementById('tab-fav')!.innerHTML = listHtml(
             favCards,
             'Aucun favori pour l’instant. Touchez ☆ sur une session pour l’ajouter ici.'
         )
 
-        setCount('now', nowCards.length + feedbackCards.length)
+        setCount('now', nowCards.length)
+        setCount('past', pastCards.length)
         setCount('next', nextCards.length)
         setCount('all', allCards.length)
         setCount('fav', favTimes.length)

--- a/src/components/home/HomeLiveSessions.astro
+++ b/src/components/home/HomeLiveSessions.astro
@@ -99,25 +99,33 @@ const items = [...sessionItems, ...commonItems].sort(
 )
 const feedbackWindow = LIVE_DATA.feedbackWindowMinutes
 
-// Infos pratiques (onglet) : repérage des salles depuis la config.
-const ROOM_LABELS: Record<string, string> = {
-    Agilité: 'Agile',
-    Craft: 'Craft',
-    DevOps: 'DevOps',
-    Data: 'Data / IA',
-    Workshop1: 'Workshop 1',
-    Workshop2: 'Workshop 2',
-}
+// Infos pratiques (onglet) : salles regroupées par étage. L'étage est déduit du
+// numéro UCLy (C 2xx -> 2ᵉ étage, C 3xx -> 3ᵉ étage). Une salle dont le numéro ne
+// matche pas reste affichée dans un groupe "À l'étage" plutôt que de disparaître.
 const rooms = LIVE_DATA.rooms as Record<string, string>
-const roomEntry = (key: string) => {
-    const r = rooms[key]
-    return r && r !== 'TODO' ? { label: ROOM_LABELS[key], room: r } : null
+const ROOM_META: { key: string; label: string; kind: 'conf' | 'atelier' }[] = [
+    { key: 'Agilité', label: 'Agile', kind: 'conf' },
+    { key: 'Craft', label: 'Craft', kind: 'conf' },
+    { key: 'Data', label: 'Data / IA', kind: 'conf' },
+    { key: 'DevOps', label: 'DevOps', kind: 'conf' },
+    { key: 'Workshop1', label: 'Workshop 1', kind: 'atelier' },
+    { key: 'Workshop2', label: 'Workshop 2', kind: 'atelier' },
+]
+const FLOOR_LABELS: Record<string, string> = { '2': '2ᵉ étage', '3': '3ᵉ étage' }
+const floorKeyOf = (room: string): string => {
+    const m = room.match(/(\d)\d\d/)
+    return m ? m[1] : '?'
 }
-const confRooms = ['Agilité', 'Craft', 'DevOps', 'Data'].map(roomEntry).filter(Boolean) as {
+const placedRooms = ROOM_META.map((m) => ({ ...m, room: rooms[m.key] })).filter((m) => m.room && m.room !== 'TODO') as {
+    key: string
     label: string
+    kind: 'conf' | 'atelier'
     room: string
 }[]
-const workshopRooms = ['Workshop1', 'Workshop2'].map(roomEntry).filter(Boolean) as { label: string; room: string }[]
+const floorGroups = [...new Set(placedRooms.map((r) => floorKeyOf(r.room)))].sort().map((fk) => ({
+    label: FLOOR_LABELS[fk] ?? 'À l’étage',
+    rooms: placedRooms.filter((r) => floorKeyOf(r.room) === fk),
+}))
 const amphiRaw = rooms['Commun'] && rooms['Commun'] !== 'TODO' ? rooms['Commun'] : null
 // Évite la répétition "(RDC)" sous l'en-tête "Rez-de-chaussée".
 const amphi = amphiRaw ? amphiRaw.replace(/\s*\(RDC\)\s*$/i, '') : null
@@ -174,104 +182,67 @@ const eventHashtag = '#QueLeLamaSoitAvecNous'
         {/* Onglet Infos pratiques — contenu statique (rendu au build) */}
         <div id="tab-info" class="live-panel" role="tabpanel" hidden>
             <div class="grid gap-4">
-                <div class="card p-5">
-                    <h3 class="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">🧭 Se repérer</h3>
-                    <div class="flex flex-col gap-4">
-                        <div class="flex items-start gap-3">
-                            <span class="text-2xl" aria-hidden="true">🏛️</span>
-                            <div>
-                                <p class="font-bold text-gray-900">Rez-de-chaussée</p>
-                                <p class="text-sm text-gray-600">
-                                    {amphi ? `${amphi} : ` : ''}keynotes (ouverture &amp; clôture), restauration, café
-                                    et stands partenaires.
-                                </p>
-                            </div>
-                        </div>
-                        <div class="flex items-start gap-3">
-                            <span class="text-2xl" aria-hidden="true">⬆️</span>
-                            <div class="flex-1">
-                                <p class="font-bold text-gray-900">À l'étage — suivez les affiches</p>
-                                <p class="text-sm text-gray-600 mb-3">
-                                    Les conférences et ateliers se tiennent à l'étage, dans un autre espace.
-                                </p>
-                                {
-                                    confRooms.length > 0 && (
-                                        <div class="mb-2">
-                                            <p class="text-xs font-semibold text-gray-400 uppercase mb-1">
-                                                Conférences
-                                            </p>
-                                            <div class="flex flex-wrap gap-2">
-                                                {confRooms.map((r) => (
-                                                    <span class="inline-flex items-center gap-1.5 text-sm bg-gray-100 rounded-lg px-2.5 py-1">
-                                                        <span class="font-semibold text-gray-800">{r.label}</span>
-                                                        <span class="text-gray-500">{r.room}</span>
-                                                    </span>
-                                                ))}
-                                            </div>
-                                        </div>
-                                    )
-                                }
-                                {
-                                    workshopRooms.length > 0 && (
-                                        <div>
-                                            <p class="text-xs font-semibold text-gray-400 uppercase mb-1">Ateliers</p>
-                                            <div class="flex flex-wrap gap-2">
-                                                {workshopRooms.map((r) => (
-                                                    <span class="inline-flex items-center gap-1.5 text-sm bg-gray-100 rounded-lg px-2.5 py-1">
-                                                        <span class="font-semibold text-gray-800">{r.label}</span>
-                                                        <span class="text-gray-500">{r.room}</span>
-                                                    </span>
-                                                ))}
-                                            </div>
-                                        </div>
-                                    )
-                                }
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="card p-5">
-                    <h3 class="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">📶 WiFi</h3>
-                    {
-                        wifiSsid ? (
-                            <div class="flex flex-col gap-1 text-sm">
-                                <div class="flex justify-between gap-3">
-                                    <span class="text-gray-500">Réseau</span>
-                                    <span class="font-mono font-semibold text-gray-900">{wifiSsid}</span>
+                {/* Se repérer : keynotes au RDC, conférences regroupées par étage. */}
+                <div class="card p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-4">Se repérer</h3>
+                    <div class="space-y-5">
+                        {
+                            amphi && (
+                                <div>
+                                    <p class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-1">
+                                        Rez-de-chaussée
+                                    </p>
+                                    <p class="text-sm text-gray-700">
+                                        <span class="font-semibold text-gray-900">{amphi}</span> — keynotes,
+                                        restauration, café &amp; stands partenaires.
+                                    </p>
                                 </div>
-                                {wifiPassword && (
-                                    <div class="flex justify-between gap-3">
-                                        <span class="text-gray-500">Mot de passe</span>
-                                        <span class="font-mono font-semibold text-gray-900">{wifiPassword}</span>
+                            )
+                        }
+                        {
+                            floorGroups.map((g) => (
+                                <div>
+                                    <p class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-1">
+                                        {g.label}
+                                    </p>
+                                    <div class="divide-y divide-gray-100">
+                                        {g.rooms.map((r) => (
+                                            <div class="flex items-center justify-between py-2">
+                                                <span class="text-sm text-gray-800">
+                                                    <span class="font-semibold">{r.label}</span>
+                                                    {r.kind === 'atelier' && (
+                                                        <span class="ml-2 text-xs text-gray-400">Atelier</span>
+                                                    )}
+                                                </span>
+                                                <span class="font-mono text-sm text-gray-500">{r.room}</span>
+                                            </div>
+                                        ))}
                                     </div>
-                                )}
-                            </div>
-                        ) : (
-                            <p class="text-sm text-gray-600">Les identifiants seront communiqués sur place.</p>
-                        )
-                    }
+                                </div>
+                            ))
+                        }
+                    </div>
+                    <p class="text-xs text-gray-400 mt-4">Suivez les affiches pour rejoindre les salles à l'étage.</p>
                 </div>
 
-                <div class="card p-5">
-                    <h3 class="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">
-                        🆘 Un souci, une urgence ?
-                    </h3>
-                    <p class="text-sm text-gray-600 mb-3">
+                {/* Besoin d'aide : contacts orga (réassemblés côté client), CoC. */}
+                <div class="card p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-1">Besoin d'aide ?</h3>
+                    <p class="text-sm text-gray-600 mb-4">
                         Malaise, objet perdu, comportement déplacé, accessibilité… appelle un organisateur, on répond
                         tout de suite.
                     </p>
                     {
-                        /* Liens tel: réassemblés côté client (cf. frontmatter) pour ne pas exposer les numéros aux crawlers. */
+                        /* Liens tel: réassemblés depuis du base64 côté client (cf. frontmatter) pour ne pas exposer les numéros. */
                     }
                     <div
                         id="live-contacts"
-                        class="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-3"
+                        class="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4"
                         data-contacts={JSON.stringify(emergencyContacts)}>
                     </div>
-                    <div class="flex flex-col sm:flex-row gap-2">
-                        <a href={`mailto:${contactEmail}`} class="btn btn-secondary flex-1 justify-center text-sm">
-                            ✉️ Écrire à l'orga
+                    <div class="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+                        <a href={`mailto:${contactEmail}`} class="text-primary-600 hover:underline">
+                            Écrire à l'orga
                         </a>
                         {
                             whatsappUrl && (
@@ -279,52 +250,67 @@ const eventHashtag = '#QueLeLamaSoitAvecNous'
                                     href={whatsappUrl}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    class="btn btn-secondary flex-1 justify-center text-sm">
-                                    💬 Groupe WhatsApp
+                                    class="text-primary-600 hover:underline">
+                                    Groupe WhatsApp
+                                </a>
+                            )
+                        }
+                        {
+                            cocUrl && (
+                                <a href={cocUrl} class="text-primary-600 hover:underline">
+                                    Code de conduite
                                 </a>
                             )
                         }
                     </div>
-                    {
-                        cocUrl && (
-                            <a href={cocUrl} class="inline-block text-sm text-primary-600 hover:underline mt-3">
-                                📜 Lire le code de conduite
-                            </a>
-                        )
-                    }
                 </div>
 
-                <div class="card p-5">
-                    <h3 class="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">
-                        📱 Partagez votre journée
-                    </h3>
-                    <p class="text-sm text-gray-600 mb-3">
-                        Postez vos photos et retours avec le hashtag officiel — touchez-le pour le copier.
-                    </p>
-                    <div class="flex flex-col sm:flex-row gap-2">
-                        <button
-                            type="button"
-                            data-copy={eventHashtag}
-                            class="btn btn-secondary flex-1 justify-center text-sm font-mono">
-                            {eventHashtag}
-                            <span data-copy-feedback class="ml-1 not-italic font-sans"></span>
-                        </button>
+                {/* Infos pratiques : WiFi + partage. */}
+                <div class="card p-6">
+                    <h3 class="text-lg font-bold text-gray-900 mb-4">Infos pratiques</h3>
+                    <div class="flex items-center justify-between gap-3">
+                        <span class="text-sm font-semibold text-gray-700">WiFi</span>
                         {
-                            linkedinUrl && (
-                                <a
-                                    href={linkedinUrl}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    class="btn btn-secondary flex-1 justify-center text-sm">
-                                    💼 Page LinkedIn
-                                </a>
+                            wifiSsid ? (
+                                <span class="text-sm text-right">
+                                    <span class="font-mono font-semibold text-gray-900">{wifiSsid}</span>
+                                    {wifiPassword && <span class="text-gray-400"> · </span>}
+                                    {wifiPassword && <span class="font-mono text-gray-600">{wifiPassword}</span>}
+                                </span>
+                            ) : (
+                                <span class="text-sm text-gray-500">communiqué sur place</span>
                             )
                         }
+                    </div>
+                    <div class="border-t border-gray-100 mt-4 pt-4">
+                        <p class="text-sm text-gray-600 mb-2">
+                            Partagez votre journée avec le hashtag officiel — touchez-le pour le copier.
+                        </p>
+                        <div class="flex flex-wrap items-center gap-3">
+                            <button
+                                type="button"
+                                data-copy={eventHashtag}
+                                class="inline-flex items-center gap-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 transition-colors px-3 py-1.5 text-sm font-mono text-gray-800">
+                                {eventHashtag}
+                                <span data-copy-feedback class="font-sans text-xs text-green-600"></span>
+                            </button>
+                            {
+                                linkedinUrl && (
+                                    <a
+                                        href={linkedinUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        class="text-sm text-primary-600 hover:underline">
+                                        Page LinkedIn
+                                    </a>
+                                )
+                            }
+                        </div>
                     </div>
                 </div>
 
                 <div class="text-center">
-                    <a href="/location" class="text-sm text-primary-600 hover:underline">📍 Plan d'accès &amp; venue</a>
+                    <a href="/location" class="text-sm text-primary-600 hover:underline">Plan d'accès &amp; venue</a>
                 </div>
             </div>
         </div>
@@ -675,9 +661,10 @@ const eventHashtag = '#QueLeLamaSoitAvecNous'
             .map((c) => {
                 const tel = atob(c.t).replace(/[^+\d]/g, '')
                 const disp = atob(c.d)
-                return `<a href="tel:${tel}" class="btn btn-primary justify-center text-sm flex flex-col items-center gap-0.5 py-2">
-                    <span>📞 ${esc(c.n)}</span>
-                    <span class="font-mono text-xs opacity-90">${esc(disp)}</span>
+                return `<a href="tel:${tel}" class="flex items-center gap-3 rounded-xl border border-gray-200 px-4 py-3 hover:border-primary-400 hover:bg-primary-50/50 transition-colors">
+                    <span class="text-lg" aria-hidden="true">📞</span>
+                    <span class="flex-1 font-semibold text-gray-900">${esc(c.n)}</span>
+                    <span class="font-mono text-sm text-gray-500">${esc(disp)}</span>
                 </a>`
             })
             .join('')

--- a/src/components/home/HomeLiveSessions.astro
+++ b/src/components/home/HomeLiveSessions.astro
@@ -1,0 +1,593 @@
+---
+// Phase live : sections temps réel rendues côté client à partir d'un JSON sérialisé
+// au build. Recalcul toutes les 30 s + au changement de favori. Heures comparées en
+// heure locale naïve (cohérent avec conference-hall.ts / fixTimestamp).
+import { getScheduleData } from '../../data/conference-hall'
+import { getFeedbackUrl } from '../../data/openfeedback'
+import { LIVE_DATA, SOCIAL_DATA, SERVICES_DATA } from '../../config'
+
+const { sessions, speakers, tracks, commonSessions } = getScheduleData()
+
+const TRACK_STYLE: Record<string, { icon: string; color: string }> = {
+    'agilit-': { icon: '🔄', color: '#e67e22' },
+    craft: { icon: '🛠️', color: '#2ecc71' },
+    devops: { icon: '☁️', color: '#3498db' },
+    data: { icon: '📊', color: '#9b59b6' },
+    workshop: { icon: '🧪', color: '#f59e0b' },
+}
+const KEYNOTE_STYLE = { icon: '🎤', color: '#6366f1' }
+
+const COMMON_ICONS: Record<string, string> = {
+    Accueil: '☕',
+    Introduction: '🎬',
+    Pause: '☕',
+    déjeuner: '🍽️',
+    Remerciements: '🎤',
+    Afterwork: '🍻',
+}
+function commonIcon(title: string): string {
+    for (const [key, icon] of Object.entries(COMMON_ICONS)) {
+        if (title.includes(key)) return icon
+    }
+    return '📌'
+}
+
+type LiveItem = {
+    id: string
+    title: string
+    start: string
+    end: string
+    kind: 'talk' | 'keynote' | 'common'
+    trackLabel: string
+    trackIcon: string
+    trackColor: string
+    room: string | null
+    level: string | null
+    speakers: { id: string; name: string; company: string | null | undefined; photoUrl: string | null | undefined }[]
+    sessionUrl: string | null
+    feedbackUrl: string | null
+}
+
+const sessionItems: LiveItem[] = sessions
+    .filter((s) => s.dateStart && s.dateEnd)
+    .map((s) => {
+        const isKeynote = s.trackId === null
+        const track = tracks.find((t) => t.id === s.trackId)
+        const style = isKeynote ? KEYNOTE_STYLE : TRACK_STYLE[s.trackId ?? ''] || { icon: '🎯', color: '#6b7280' }
+        const sessionSpeakers = speakers
+            .filter((sp) => s.speakerIds.includes(sp.id))
+            .map((sp) => ({ id: sp.id, name: sp.name, company: sp.company, photoUrl: sp.photoUrl }))
+        return {
+            id: s.id,
+            title: s.title,
+            start: s.dateStart as string,
+            end: s.dateEnd as string,
+            kind: isKeynote ? 'keynote' : 'talk',
+            trackLabel: isKeynote ? 'Keynote' : track?.name || '',
+            trackIcon: style.icon,
+            trackColor: style.color,
+            room: s.room,
+            level: s.level,
+            speakers: sessionSpeakers,
+            sessionUrl: `/sessions/${s.id}?from=live`,
+            feedbackUrl: getFeedbackUrl({
+                sessionId: s.id,
+                dateStart: s.dateStart as string,
+                hasSpeakers: s.speakerIds.length > 0,
+            }),
+        }
+    })
+
+const commonItems: LiveItem[] = commonSessions.map((c) => ({
+    id: c.id,
+    title: c.title,
+    start: c.dateStart,
+    end: c.dateEnd,
+    kind: 'common',
+    trackLabel: '',
+    trackIcon: commonIcon(c.title),
+    trackColor: '#6b7280',
+    room: null,
+    level: null,
+    speakers: [],
+    sessionUrl: null,
+    feedbackUrl: null,
+}))
+
+const items = [...sessionItems, ...commonItems].sort(
+    (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime()
+)
+const feedbackWindow = LIVE_DATA.feedbackWindowMinutes
+
+// Infos pratiques (onglet) : repérage des salles depuis la config.
+const ROOM_LABELS: Record<string, string> = {
+    Agilité: 'Agile',
+    Craft: 'Craft',
+    DevOps: 'DevOps',
+    Data: 'Data / IA',
+    Workshop1: 'Workshop 1',
+    Workshop2: 'Workshop 2',
+}
+const rooms = LIVE_DATA.rooms as Record<string, string>
+const roomEntry = (key: string) => {
+    const r = rooms[key]
+    return r && r !== 'TODO' ? { label: ROOM_LABELS[key], room: r } : null
+}
+const confRooms = ['Agilité', 'Craft', 'DevOps', 'Data'].map(roomEntry).filter(Boolean) as {
+    label: string
+    room: string
+}[]
+const workshopRooms = ['Workshop1', 'Workshop2'].map(roomEntry).filter(Boolean) as { label: string; room: string }[]
+const amphiRaw = rooms['Commun'] && rooms['Commun'] !== 'TODO' ? rooms['Commun'] : null
+// Évite la répétition "(RDC)" sous l'en-tête "Rez-de-chaussée".
+const amphi = amphiRaw ? amphiRaw.replace(/\s*\(RDC\)\s*$/i, '') : null
+const contactEmail = SOCIAL_DATA.contact.general
+const whatsappUrl = SERVICES_DATA.community.whatsapp.inviteUrl
+const wifi = (LIVE_DATA as { wifi?: { ssid?: string; password?: string } }).wifi
+const wifiSsid = wifi?.ssid ? wifi.ssid : null
+const wifiPassword = wifi?.password ? wifi.password : null
+---
+
+<section class="py-10 sm:py-14" data-feedback-window={feedbackWindow}>
+    <script type="application/json" id="live-data" set:html={JSON.stringify(items)} is:inline />
+
+    <div class="max-w-3xl mx-auto px-5">
+        {/* Onglets */}
+        <div class="live-tabs" role="tablist" aria-label="Vue du programme">
+            <button type="button" class="live-tab" data-tab="now" role="tab" aria-selected="true">
+                🔴 En ce moment <span class="live-tab-count" data-count="now"></span>
+            </button>
+            <button type="button" class="live-tab" data-tab="next" role="tab" aria-selected="false">
+                ⏭️ À venir <span class="live-tab-count" data-count="next"></span>
+            </button>
+            <button type="button" class="live-tab" data-tab="all" role="tab" aria-selected="false">
+                📅 Tous <span class="live-tab-count" data-count="all"></span>
+            </button>
+            <button type="button" class="live-tab" data-tab="fav" role="tab" aria-selected="false">
+                ⭐ Favoris <span class="live-tab-count" data-count="fav"></span>
+            </button>
+            <button type="button" class="live-tab" data-tab="info" role="tab" aria-selected="false"> ℹ️ Infos </button>
+        </div>
+
+        {/* Panneaux */}
+        <div id="tab-now" class="live-panel" role="tabpanel"></div>
+        <div id="tab-next" class="live-panel" role="tabpanel" hidden></div>
+        <div id="tab-all" class="live-panel" role="tabpanel" hidden></div>
+        <div id="tab-fav" class="live-panel" role="tabpanel" hidden></div>
+
+        {/* Onglet Infos pratiques — contenu statique (rendu au build) */}
+        <div id="tab-info" class="live-panel" role="tabpanel" hidden>
+            <div class="grid gap-4">
+                <div class="card p-5">
+                    <h3 class="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">🧭 Se repérer</h3>
+                    <div class="flex flex-col gap-4">
+                        <div class="flex items-start gap-3">
+                            <span class="text-2xl" aria-hidden="true">🏛️</span>
+                            <div>
+                                <p class="font-bold text-gray-900">Rez-de-chaussée</p>
+                                <p class="text-sm text-gray-600">
+                                    {amphi ? `${amphi} : ` : ''}keynotes (ouverture &amp; clôture), restauration, café
+                                    et stands partenaires.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="flex items-start gap-3">
+                            <span class="text-2xl" aria-hidden="true">⬆️</span>
+                            <div class="flex-1">
+                                <p class="font-bold text-gray-900">À l'étage — suivez les affiches</p>
+                                <p class="text-sm text-gray-600 mb-3">
+                                    Les conférences et ateliers se tiennent à l'étage, dans un autre espace.
+                                </p>
+                                {
+                                    confRooms.length > 0 && (
+                                        <div class="mb-2">
+                                            <p class="text-xs font-semibold text-gray-400 uppercase mb-1">
+                                                Conférences
+                                            </p>
+                                            <div class="flex flex-wrap gap-2">
+                                                {confRooms.map((r) => (
+                                                    <span class="inline-flex items-center gap-1.5 text-sm bg-gray-100 rounded-lg px-2.5 py-1">
+                                                        <span class="font-semibold text-gray-800">{r.label}</span>
+                                                        <span class="text-gray-500">{r.room}</span>
+                                                    </span>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    )
+                                }
+                                {
+                                    workshopRooms.length > 0 && (
+                                        <div>
+                                            <p class="text-xs font-semibold text-gray-400 uppercase mb-1">Ateliers</p>
+                                            <div class="flex flex-wrap gap-2">
+                                                {workshopRooms.map((r) => (
+                                                    <span class="inline-flex items-center gap-1.5 text-sm bg-gray-100 rounded-lg px-2.5 py-1">
+                                                        <span class="font-semibold text-gray-800">{r.label}</span>
+                                                        <span class="text-gray-500">{r.room}</span>
+                                                    </span>
+                                                ))}
+                                            </div>
+                                        </div>
+                                    )
+                                }
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card p-5">
+                    <h3 class="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">📶 WiFi</h3>
+                    {
+                        wifiSsid ? (
+                            <div class="flex flex-col gap-1 text-sm">
+                                <div class="flex justify-between gap-3">
+                                    <span class="text-gray-500">Réseau</span>
+                                    <span class="font-mono font-semibold text-gray-900">{wifiSsid}</span>
+                                </div>
+                                {wifiPassword && (
+                                    <div class="flex justify-between gap-3">
+                                        <span class="text-gray-500">Mot de passe</span>
+                                        <span class="font-mono font-semibold text-gray-900">{wifiPassword}</span>
+                                    </div>
+                                )}
+                            </div>
+                        ) : (
+                            <p class="text-sm text-gray-600">Les identifiants seront communiqués sur place.</p>
+                        )
+                    }
+                </div>
+
+                <div class="card p-5">
+                    <h3 class="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">🆘 Besoin d'aide ?</h3>
+                    <div class="flex flex-col sm:flex-row gap-3">
+                        <a href={`mailto:${contactEmail}`} class="btn btn-secondary flex-1 justify-center text-sm">
+                            ✉️ Contacter l'orga
+                        </a>
+                        {
+                            whatsappUrl && (
+                                <a
+                                    href={whatsappUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="btn btn-secondary flex-1 justify-center text-sm">
+                                    💬 Groupe WhatsApp
+                                </a>
+                            )
+                        }
+                    </div>
+                </div>
+
+                <div class="text-center">
+                    <a href="/location" class="text-sm text-primary-600 hover:underline">📍 Plan d'accès &amp; venue</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="text-center mt-8">
+            <a href="/schedule" class="btn btn-secondary inline-flex items-center gap-2"> 📅 Programme complet </a>
+        </div>
+    </div>
+</section>
+
+<style>
+    .live-tabs {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-bottom: 20px;
+    }
+    /* Mobile : 2 colonnes (2×2), les 4 onglets visibles sans scroll. */
+    .live-tab {
+        flex: 1 1 calc(50% - 4px);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        padding: 10px 8px;
+        border-radius: 9999px;
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: #475569;
+        background: #f1f5f9;
+        border: 1px solid transparent;
+        cursor: pointer;
+        white-space: nowrap;
+        transition: all 0.15s;
+    }
+    /* Desktop : une seule ligne, largeur au contenu. */
+    @media (min-width: 640px) {
+        .live-tab {
+            flex: 0 1 auto;
+            padding: 8px 14px;
+            font-size: 0.85rem;
+        }
+    }
+    .live-tab:hover {
+        background: #e2e8f0;
+    }
+    .live-tab[aria-selected='true'] {
+        color: white;
+        background: linear-gradient(to right, #4f46e5, #4338ca);
+        box-shadow: 0 4px 12px rgba(79, 70, 229, 0.25);
+    }
+    .live-tab-count:empty {
+        display: none;
+    }
+    .live-tab-count {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 18px;
+        height: 18px;
+        padding: 0 5px;
+        border-radius: 9999px;
+        font-size: 0.7rem;
+        font-weight: 700;
+        background: rgba(255, 255, 255, 0.25);
+    }
+    .live-tab[aria-selected='false'] .live-tab-count {
+        background: #cbd5e1;
+        color: #475569;
+    }
+    .live-panel[hidden] {
+        display: none;
+    }
+</style>
+
+<script>
+    const FAV_KEY = 'techwork-live-favorites'
+
+    function getNow(): Date {
+        try {
+            const p = new URLSearchParams(window.location.search).get('now')
+            if (p) {
+                const d = new Date(p)
+                if (!isNaN(d.getTime())) return d
+            }
+        } catch (e) {}
+        return new Date()
+    }
+
+    function getFavs(): string[] {
+        try {
+            return JSON.parse(localStorage.getItem(FAV_KEY) || '[]')
+        } catch (e) {
+            return []
+        }
+    }
+    function setFavs(ids: string[]) {
+        try {
+            localStorage.setItem(FAV_KEY, JSON.stringify(ids))
+        } catch (e) {}
+    }
+
+    type LiveItem = {
+        id: string
+        title: string
+        start: string
+        end: string
+        kind: 'talk' | 'keynote' | 'common'
+        trackLabel: string
+        trackIcon: string
+        trackColor: string
+        room: string | null
+        level: string | null
+        speakers: { id: string; name: string; company: string | null; photoUrl: string | null }[]
+        sessionUrl: string | null
+        feedbackUrl: string | null
+    }
+
+    const LEVEL_LABELS: Record<string, string> = {
+        BEGINNER: 'Débutant',
+        INTERMEDIATE: 'Intermédiaire',
+        ADVANCED: 'Avancé',
+    }
+
+    function fmtTime(iso: string): string {
+        return new Date(iso).toLocaleTimeString('fr', { hour: '2-digit', minute: '2-digit' })
+    }
+    function esc(s: string): string {
+        const d = document.createElement('div')
+        d.textContent = s
+        return d.innerHTML
+    }
+
+    function speakersHtml(it: LiveItem): string {
+        if (!it.speakers || it.speakers.length === 0) return ''
+        const names = it.speakers.map((s) => esc(s.name)).join(', ')
+        return `<p class="text-sm text-gray-600">🎙️ ${names}</p>`
+    }
+
+    // Badge de statut temporel d'une session.
+    function statusBadge(startT: number, endT: number, nowMs: number): string {
+        if (startT <= nowMs && nowMs < endT) {
+            return `<span class="inline-flex items-center gap-1 text-xs font-bold text-red-700 bg-red-100 rounded-full px-2.5 py-0.5">● En cours</span>`
+        }
+        if (endT <= nowMs) {
+            return `<span class="inline-block text-xs font-semibold text-gray-500 bg-gray-100 rounded-full px-2.5 py-0.5">Terminé</span>`
+        }
+        const mins = Math.round((startT - nowMs) / 60000)
+        const label =
+            mins < 60
+                ? `dans ${mins} min`
+                : `dans ${Math.floor(mins / 60)} h ${(mins % 60).toString().padStart(2, '0')}`
+        return `<span class="inline-block text-xs font-semibold text-primary-700 bg-primary-50 rounded-full px-2.5 py-0.5">${label}</span>`
+    }
+
+    function buildCard(it: LiveItem, favs: string[], opts: { feedback?: boolean; statusHtml?: string } = {}): string {
+        const isFav = favs.indexOf(it.id) !== -1
+        // Carte entièrement cliquable (comme le programme) : un clic n'importe où
+        // déclenche le lien du titre (géré par délégation dans onClick), sauf sur
+        // l'étoile ou un lien interne (feedback).
+        const titleHtml = it.sessionUrl
+            ? `<a href="${it.sessionUrl}" data-card-link class="hover:text-primary-600 transition-colors">${esc(it.title)}</a>`
+            : esc(it.title)
+        const meta: string[] = [`${it.trackIcon} ${esc(it.trackLabel || '')}`.trim()]
+        if (it.room) meta.push(`📍 ${esc(it.room)}`)
+        if (it.level && LEVEL_LABELS[it.level]) meta.push(LEVEL_LABELS[it.level])
+        const favBtn =
+            it.kind === 'common'
+                ? ''
+                : `<button type="button" class="fav-btn text-2xl leading-none flex-shrink-0" data-fav="${it.id}" aria-pressed="${isFav}" aria-label="${
+                      isFav ? 'Retirer des favoris' : 'Ajouter aux favoris'
+                  }">${isFav ? '★' : '☆'}</button>`
+        const feedbackBtn =
+            opts.feedback && it.feedbackUrl
+                ? `<a href="${it.feedbackUrl}" target="_blank" rel="noopener noreferrer" class="btn btn-primary w-full justify-center text-sm mt-1">💬 Donner mon avis</a>`
+                : ''
+        const cardAttr = it.sessionUrl ? ' data-session-card' : ''
+        return `
+        <article class="card p-4 flex flex-col gap-2${it.sessionUrl ? ' cursor-pointer hover:shadow-lg transition-shadow' : ''}"${cardAttr} style="border-left:4px solid ${it.trackColor}">
+            <div class="flex items-start justify-between gap-2">
+                <span class="text-sm font-semibold text-gray-900">${fmtTime(it.start)} – ${fmtTime(it.end)}</span>
+                <div class="flex items-center gap-2 flex-shrink-0">${opts.statusHtml || ''}${favBtn}</div>
+            </div>
+            <div class="text-xs text-gray-500">${meta.filter(Boolean).join(' · ')}</div>
+            <h3 class="text-base font-bold text-gray-900 leading-snug">${titleHtml}</h3>
+            ${speakersHtml(it)}
+            ${feedbackBtn}
+        </article>`
+    }
+
+    function listHtml(cards: string[], emptyMsg: string): string {
+        if (cards.length === 0) return `<p class="text-center text-gray-500 py-8">${emptyMsg}</p>`
+        return `<div class="grid gap-3">${cards.join('')}</div>`
+    }
+    function blockHtml(title: string, cards: string[]): string {
+        if (cards.length === 0) return ''
+        return `<div class="mb-6"><h3 class="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">${title}</h3><div class="grid gap-3">${cards.join('')}</div></div>`
+    }
+
+    const TAB_KEY = 'techwork-live-tab'
+    let activeTab = 'now'
+
+    function showTab(tab: string) {
+        activeTab = tab
+        try {
+            sessionStorage.setItem(TAB_KEY, tab)
+        } catch (e) {}
+        ;['now', 'next', 'all', 'fav', 'info'].forEach((t) => {
+            const panel = document.getElementById('tab-' + t)
+            if (panel) (panel as HTMLElement).hidden = t !== tab
+        })
+        document.querySelectorAll('.live-tab').forEach((b) => {
+            b.setAttribute('aria-selected', b.getAttribute('data-tab') === tab ? 'true' : 'false')
+        })
+    }
+
+    function setCount(name: string, n: number) {
+        document.querySelectorAll(`.live-tab-count[data-count="${name}"]`).forEach((el) => {
+            el.textContent = String(n)
+        })
+    }
+
+    function render() {
+        const dataEl = document.getElementById('live-data')
+        const root = document.querySelector('[data-feedback-window]') as HTMLElement | null
+        if (!dataEl || !root) return
+        let data: LiveItem[] = []
+        try {
+            data = JSON.parse(dataEl.textContent || '[]')
+        } catch (e) {
+            return
+        }
+        const feedbackWindowMs = parseInt(root.getAttribute('data-feedback-window') || '20', 10) * 60000
+        const nowMs = getNow().getTime()
+        const favs = getFavs()
+
+        const withTimes = data
+            .map((d) => ({ it: d, startT: new Date(d.start).getTime(), endT: new Date(d.end).getTime() }))
+            .sort((a, b) => a.startT - b.startT)
+
+        // Onglet "En ce moment" : feedback (sessions tout juste finies) + sessions en cours.
+        const feedbackCards = withTimes
+            .filter((x) => x.it.feedbackUrl && x.endT <= nowMs && nowMs - x.endT <= feedbackWindowMs)
+            .sort((a, b) => b.endT - a.endT)
+            .map((x) => buildCard(x.it, favs, { feedback: true }))
+        const nowCards = withTimes
+            .filter((x) => x.startT <= nowMs && nowMs < x.endT)
+            .map((x) => buildCard(x.it, favs, { statusHtml: statusBadge(x.startT, x.endT, nowMs) }))
+        const nowPanel =
+            blockHtml('💬 Donnez votre avis', feedbackCards) +
+            (nowCards.length
+                ? blockHtml('🔴 En cours', nowCards)
+                : feedbackCards.length
+                  ? ''
+                  : listHtml([], 'Aucune session en cours pour le moment.'))
+
+        // Onglet "Plus tard" : tout ce qui démarre après maintenant.
+        const nextCards = withTimes
+            .filter((x) => x.startT > nowMs)
+            .map((x) => buildCard(x.it, favs, { statusHtml: statusBadge(x.startT, x.endT, nowMs) }))
+
+        // Onglet "Tout le programme" : toute la journée, avec statut.
+        const allCards = withTimes.map((x) =>
+            buildCard(x.it, favs, { statusHtml: statusBadge(x.startT, x.endT, nowMs) })
+        )
+
+        // Onglet "Favoris".
+        const favTimes = withTimes.filter((x) => favs.indexOf(x.it.id) !== -1)
+        const favCards = favTimes.map((x) =>
+            buildCard(x.it, favs, { statusHtml: statusBadge(x.startT, x.endT, nowMs) })
+        )
+
+        document.getElementById('tab-now')!.innerHTML = nowPanel
+        document.getElementById('tab-next')!.innerHTML = listHtml(nextCards, 'Plus de sessions à venir aujourd’hui.')
+        document.getElementById('tab-all')!.innerHTML = listHtml(allCards, 'Programme indisponible.')
+        document.getElementById('tab-fav')!.innerHTML = listHtml(
+            favCards,
+            'Aucun favori pour l’instant. Touchez ☆ sur une session pour l’ajouter ici.'
+        )
+
+        setCount('now', nowCards.length)
+        setCount('next', nextCards.length)
+        setCount('all', allCards.length)
+        setCount('fav', favTimes.length)
+    }
+
+    function onClick(e: Event) {
+        const target = e.target as HTMLElement
+        const tabBtn = target.closest('.live-tab') as HTMLElement | null
+        if (tabBtn) {
+            const tab = tabBtn.getAttribute('data-tab')
+            if (tab) showTab(tab)
+            return
+        }
+        const favBtn = target.closest('.fav-btn') as HTMLElement | null
+        if (favBtn) {
+            const id = favBtn.getAttribute('data-fav')
+            if (!id) return
+            const favs = getFavs()
+            const idx = favs.indexOf(id)
+            if (idx === -1) favs.push(id)
+            else favs.splice(idx, 1)
+            setFavs(favs)
+            render()
+            return
+        }
+        // Carte cliquable : tout clic ailleurs que sur un lien déclenche le lien du titre.
+        if (target.closest('a')) return
+        const card = target.closest('[data-session-card]') as HTMLElement | null
+        if (card) {
+            const link = card.querySelector('a[data-card-link]') as HTMLAnchorElement | null
+            if (link) link.click()
+        }
+    }
+
+    function init() {
+        if (!document.getElementById('live-data')) return
+        try {
+            activeTab = sessionStorage.getItem(TAB_KEY) || activeTab
+        } catch (e) {}
+        showTab(activeTab)
+        render()
+    }
+
+    document.addEventListener('click', onClick)
+    document.addEventListener('astro:page-load', init)
+    document.addEventListener('astro:after-swap', init)
+    setInterval(() => {
+        if (document.getElementById('live-data')) render()
+    }, 30000)
+    init()
+</script>

--- a/src/components/home/HomeLiveSessions.astro
+++ b/src/components/home/HomeLiveSessions.astro
@@ -126,6 +126,22 @@ const whatsappUrl = SERVICES_DATA.community.whatsapp.inviteUrl
 const wifi = (LIVE_DATA as { wifi?: { ssid?: string; password?: string } }).wifi
 const wifiSsid = wifi?.ssid ? wifi.ssid : null
 const wifiPassword = wifi?.password ? wifi.password : null
+
+// Contacts d'urgence jour J. On encode en base64 et on réassemble le lien tel:
+// côté client : aucun numéro ni href "tel:" en clair dans le HTML statique, donc
+// les crawlers/scrapers basiques (regex sur les chiffres ou sur tel:) repartent
+// bredouilles. Réversible facilement, ce n'est pas du chiffrement — juste un repoussoir.
+const enc = (s: string) => Buffer.from(s, 'utf8').toString('base64')
+const emergencyContacts = [
+    { name: 'Xavier', tel: '+33673474053', display: '06 73 47 40 53' },
+    { name: 'Maxime', tel: '+33683637026', display: '06 83 63 70 26' },
+].map((c) => ({ n: c.name, t: enc(c.tel), d: enc(c.display) }))
+
+const cocUrl = SERVICES_DATA.legal.codeOfConduct
+const linkedinUrl = SOCIAL_DATA.networks.find((n) => n.id === 'linkedin')?.url ?? null
+// Hashtag officiel acté par l'orga (cf. checklist jour J), distinct des hashtags
+// génériques de social.json.
+const eventHashtag = '#QueLeLamaSoitAvecNous'
 ---
 
 <section class="py-10 sm:py-14" data-feedback-window={feedbackWindow}>
@@ -238,10 +254,24 @@ const wifiPassword = wifi?.password ? wifi.password : null
                 </div>
 
                 <div class="card p-5">
-                    <h3 class="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">🆘 Besoin d'aide ?</h3>
-                    <div class="flex flex-col sm:flex-row gap-3">
+                    <h3 class="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">
+                        🆘 Un souci, une urgence ?
+                    </h3>
+                    <p class="text-sm text-gray-600 mb-3">
+                        Malaise, objet perdu, comportement déplacé, accessibilité… appelle un organisateur, on répond
+                        tout de suite.
+                    </p>
+                    {
+                        /* Liens tel: réassemblés côté client (cf. frontmatter) pour ne pas exposer les numéros aux crawlers. */
+                    }
+                    <div
+                        id="live-contacts"
+                        class="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-3"
+                        data-contacts={JSON.stringify(emergencyContacts)}>
+                    </div>
+                    <div class="flex flex-col sm:flex-row gap-2">
                         <a href={`mailto:${contactEmail}`} class="btn btn-secondary flex-1 justify-center text-sm">
-                            ✉️ Contacter l'orga
+                            ✉️ Écrire à l'orga
                         </a>
                         {
                             whatsappUrl && (
@@ -251,6 +281,42 @@ const wifiPassword = wifi?.password ? wifi.password : null
                                     rel="noopener noreferrer"
                                     class="btn btn-secondary flex-1 justify-center text-sm">
                                     💬 Groupe WhatsApp
+                                </a>
+                            )
+                        }
+                    </div>
+                    {
+                        cocUrl && (
+                            <a href={cocUrl} class="inline-block text-sm text-primary-600 hover:underline mt-3">
+                                📜 Lire le code de conduite
+                            </a>
+                        )
+                    }
+                </div>
+
+                <div class="card p-5">
+                    <h3 class="text-sm font-bold text-gray-500 uppercase tracking-wide mb-3">
+                        📱 Partagez votre journée
+                    </h3>
+                    <p class="text-sm text-gray-600 mb-3">
+                        Postez vos photos et retours avec le hashtag officiel — touchez-le pour le copier.
+                    </p>
+                    <div class="flex flex-col sm:flex-row gap-2">
+                        <button
+                            type="button"
+                            data-copy={eventHashtag}
+                            class="btn btn-secondary flex-1 justify-center text-sm font-mono">
+                            {eventHashtag}
+                            <span data-copy-feedback class="ml-1 not-italic font-sans"></span>
+                        </button>
+                        {
+                            linkedinUrl && (
+                                <a
+                                    href={linkedinUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="btn btn-secondary flex-1 justify-center text-sm">
+                                    💼 Page LinkedIn
                                 </a>
                             )
                         }
@@ -553,6 +619,25 @@ const wifiPassword = wifi?.password ? wifi.password : null
             if (tab) showTab(tab)
             return
         }
+        const copyBtn = target.closest('[data-copy]') as HTMLElement | null
+        if (copyBtn) {
+            const txt = copyBtn.getAttribute('data-copy') || ''
+            const fb = copyBtn.querySelector('[data-copy-feedback]')
+            if (navigator.clipboard) {
+                navigator.clipboard
+                    .writeText(txt)
+                    .then(() => {
+                        if (fb) {
+                            fb.textContent = '✓ copié'
+                            setTimeout(() => {
+                                fb.textContent = ''
+                            }, 1500)
+                        }
+                    })
+                    .catch(() => {})
+            }
+            return
+        }
         const favBtn = target.closest('.fav-btn') as HTMLElement | null
         if (favBtn) {
             const id = favBtn.getAttribute('data-fav')
@@ -574,6 +659,31 @@ const wifiPassword = wifi?.password ? wifi.password : null
         }
     }
 
+    // Réassemble les liens tel: à partir des contacts encodés en base64 dans
+    // data-contacts. Idempotent : ne réinjecte pas si déjà fait (init est rejoué
+    // après chaque navigation Astro).
+    function hydrateContacts() {
+        const holder = document.getElementById('live-contacts') as HTMLElement | null
+        if (!holder || holder.dataset.hydrated) return
+        let contacts: { n: string; t: string; d: string }[] = []
+        try {
+            contacts = JSON.parse(holder.getAttribute('data-contacts') || '[]')
+        } catch (e) {
+            return
+        }
+        holder.innerHTML = contacts
+            .map((c) => {
+                const tel = atob(c.t).replace(/[^+\d]/g, '')
+                const disp = atob(c.d)
+                return `<a href="tel:${tel}" class="btn btn-primary justify-center text-sm flex flex-col items-center gap-0.5 py-2">
+                    <span>📞 ${esc(c.n)}</span>
+                    <span class="font-mono text-xs opacity-90">${esc(disp)}</span>
+                </a>`
+            })
+            .join('')
+        holder.dataset.hydrated = '1'
+    }
+
     function init() {
         if (!document.getElementById('live-data')) return
         try {
@@ -581,6 +691,7 @@ const wifiPassword = wifi?.password ? wifi.password : null
         } catch (e) {}
         showTab(activeTab)
         render()
+        hydrateContacts()
     }
 
     document.addEventListener('click', onClick)

--- a/src/components/home/HomePartnersBlock.astro
+++ b/src/components/home/HomePartnersBlock.astro
@@ -18,51 +18,52 @@ const partners = await Promise.all(
 )
 ---
 
-<section id="community-partners" class="py-12 sm:py-16 bg-gray-50 border-t border-gray-200">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="text-center mb-12 scroll-animate">
-            <div
-                class="inline-flex items-center px-4 py-2 bg-primary-100 text-primary-700 rounded-full text-sm font-semibold mb-6 animate-scale-in hover-lift">
-                <span class="mr-2 animate-bounce-gentle">🤝</span>
-                Organisation
-            </div>
-            <h2 class="text-2xl sm:text-3xl font-black text-gray-900 mb-6">
-                Les <span class="text-gradient">co-organisateurs</span>
-            </h2>
-            <p class="text-lg text-gray-600 max-w-2xl mx-auto">
-                Ces communautés tech locales participent activement à la construction de l'édition 2026.
-            </p>
-        </div>
+{
+    partners.length > 0 && (
+        <section id="community-partners" class="py-12 sm:py-16 bg-gray-50 border-t border-gray-200">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div class="text-center mb-12 scroll-animate">
+                    <div class="inline-flex items-center px-4 py-2 bg-primary-100 text-primary-700 rounded-full text-sm font-semibold mb-6 animate-scale-in hover-lift">
+                        <span class="mr-2 animate-bounce-gentle">🤝</span>
+                        Organisation
+                    </div>
+                    <h2 class="text-2xl sm:text-3xl font-black text-gray-900 mb-6">
+                        Les <span class="text-gradient">co-organisateurs</span>
+                    </h2>
+                    <p class="text-lg text-gray-600 max-w-2xl mx-auto">
+                        Ces communautés tech locales participent activement à la construction de l'édition 2026.
+                    </p>
+                </div>
 
-        <div class="flex flex-wrap justify-center items-center gap-8 sm:gap-12 stagger-children">
-            {
-                partners.map((partner, index) => (
-                    <a
-                        href={partner.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="group relative block scroll-animate-scale"
-                        style={`animation-delay: ${index * 0.1}s`}
-                        title={partner.name}
-                        aria-label={`Site web de ${partner.name}`}>
-                        <div class="bg-white p-6 rounded-2xl shadow-sm hover:shadow-lg transition-all duration-300 transform hover:-translate-y-1 flex items-center justify-center h-32 w-full xs:w-64 border border-gray-100 hover:border-primary-200">
-                            {partner.image ? (
-                                <Image
-                                    src={partner.image}
-                                    alt={`Logo ${partner.name}`}
-                                    class="max-h-20 w-auto object-contain transition-all duration-300 group-hover:scale-105 filter grayscale brightness-75 sepia hue-rotate-[220deg] saturate-[500%] opacity-90 group-hover:filter-none group-hover:opacity-100"
-                                    width={200}
-                                    height={80}
-                                    loading="lazy"
-                                    decoding="async"
-                                />
-                            ) : (
-                                <span class="text-gray-600 font-bold">{partner.name}</span>
-                            )}
-                        </div>
-                    </a>
-                ))
-            }
-        </div>
-    </div>
-</section>
+                <div class="flex flex-wrap justify-center items-center gap-8 sm:gap-12 stagger-children">
+                    {partners.map((partner, index) => (
+                        <a
+                            href={partner.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="group relative block scroll-animate-scale"
+                            style={`animation-delay: ${index * 0.1}s`}
+                            title={partner.name}
+                            aria-label={`Site web de ${partner.name}`}>
+                            <div class="bg-white p-6 rounded-2xl shadow-sm hover:shadow-lg transition-all duration-300 transform hover:-translate-y-1 flex items-center justify-center h-32 w-full xs:w-64 border border-gray-100 hover:border-primary-200">
+                                {partner.image ? (
+                                    <Image
+                                        src={partner.image}
+                                        alt={`Logo ${partner.name}`}
+                                        class="max-h-20 w-auto object-contain transition-all duration-300 group-hover:scale-105 filter grayscale brightness-75 sepia hue-rotate-[220deg] saturate-[500%] opacity-90 group-hover:filter-none group-hover:opacity-100"
+                                        width={200}
+                                        height={80}
+                                        loading="lazy"
+                                        decoding="async"
+                                    />
+                                ) : (
+                                    <span class="text-gray-600 font-bold">{partner.name}</span>
+                                )}
+                            </div>
+                        </a>
+                    ))}
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/src/components/home/HomePhaseHero.astro
+++ b/src/components/home/HomePhaseHero.astro
@@ -5,12 +5,22 @@
 import { EVENT_DATA } from '../../config'
 import { getScheduleData } from '../../data/conference-hall'
 
-const { sessions } = getScheduleData()
+const { sessions, commonSessions } = getScheduleData()
 const starts = sessions
     .map((s) => s.dateStart)
     .filter((d): d is string => !!d)
     .sort()
 const liveStart = starts.length ? starts[0] : `${EVENT_DATA.event.date.iso}T${EVENT_DATA.event.duration.startTime}:00`
+
+// Heure d'ouverture des portes = début de la 1ʳᵉ entrée du programme (accueil
+// inclus), pour rester juste si le planning bouge. Format FR : "8h30", "9h".
+const doorsIso = [...starts, ...commonSessions.map((c) => c.dateStart)].filter(Boolean).sort()[0] ?? null
+const doorsTime = doorsIso
+    ? (() => {
+          const [h, min] = doorsIso.slice(11, 16).split(':')
+          return `${parseInt(h, 10)}h${min === '00' ? '' : min}`
+      })()
+    : null
 
 const dateFull = EVENT_DATA.event.date.full
 const venue = EVENT_DATA.event.location.venue
@@ -83,7 +93,16 @@ const city = EVENT_DATA.event.location.city
                         data-event-day={EVENT_DATA.event.date.iso}>c'est bientôt</span
                     > !
                 </h1>
-                <p class="text-lg text-gray-100">Préparez votre venue à <strong>{venue}</strong>, {city}.</p>
+                <p class="text-lg text-gray-100">
+                    <strong>{venue}</strong>, {city}{
+                        doorsTime && (
+                            <Fragment>
+                                {' '}
+                                — ouverture des portes à partir de <strong>{doorsTime}</strong>
+                            </Fragment>
+                        )
+                    }.
+                </p>
             </div>
         </div>
 

--- a/src/components/home/HomePhaseHero.astro
+++ b/src/components/home/HomePhaseHero.astro
@@ -1,0 +1,117 @@
+---
+// Hero léger, affiché dans les phases preevent / live / post (le hero marketing
+// reste réservé à la phase default). Chaque variante est gatée par data-when ;
+// la variante "jour J" utilise data-eventday-only. Pas d'image lourde ici.
+import { EVENT_DATA } from '../../config'
+import { getScheduleData } from '../../data/conference-hall'
+
+const { sessions } = getScheduleData()
+const starts = sessions
+    .map((s) => s.dateStart)
+    .filter((d): d is string => !!d)
+    .sort()
+const liveStart = starts.length ? starts[0] : `${EVENT_DATA.event.date.iso}T${EVENT_DATA.event.duration.startTime}:00`
+
+const dateFull = EVENT_DATA.event.date.full
+const venue = EVENT_DATA.event.location.venue
+const city = EVENT_DATA.event.location.city
+---
+
+<section class="hero-gradient relative overflow-hidden pt-28 pb-16 sm:pt-32 sm:pb-20 text-white">
+    <div class="absolute -top-24 -right-24 w-72 h-72 bg-secondary-500/20 rounded-full blur-3xl" aria-hidden="true">
+    </div>
+    <div class="absolute -bottom-24 -left-24 w-72 h-72 bg-primary-400/20 rounded-full blur-3xl" aria-hidden="true">
+    </div>
+
+    <div class="relative max-w-3xl mx-auto px-5 text-center">
+        <!-- ============ PRE-EVENT ============ -->
+        <div data-when="preevent">
+            <!-- Variante jour J -->
+            <div data-eventday-only>
+                <span
+                    class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-white/15 border border-white/25 text-sm font-semibold mb-5">
+                    🎉 C'est aujourd'hui !
+                </span>
+                <h1 class="text-4xl sm:text-5xl font-black mb-4">Bienvenue à {EVENT_DATA.event.shortName}</h1>
+                <p class="text-lg text-gray-100 mb-2">On vous attend à <strong>{venue}</strong>, {city}.</p>
+                <p class="text-primary-100">La première conférence approche — voici comment nous rejoindre 👇</p>
+            </div>
+
+            <!-- Variante J-x (avant le jour J) -->
+            <div data-eventday-hide>
+                <span
+                    class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-white/15 border border-white/25 text-sm font-semibold mb-5">
+                    🗓️ {dateFull}
+                </span>
+                <h1 class="text-4xl sm:text-5xl font-black mb-4">{EVENT_DATA.event.shortName}, c'est bientôt !</h1>
+                <p id="countdown" class="text-2xl sm:text-3xl font-bold text-primary-100 mb-3" data-target={liveStart}>
+                    &nbsp;
+                </p>
+                <p class="text-gray-100">Préparez votre venue à <strong>{venue}</strong>, {city}.</p>
+            </div>
+        </div>
+
+        <!-- ============ LIVE ============ -->
+        <div data-when="live">
+            <span
+                class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-red-500/90 text-sm font-bold mb-5 animate-pulse">
+                🔴 En direct
+            </span>
+            <h1 class="text-4xl sm:text-5xl font-black mb-4">{EVENT_DATA.event.shortName} en cours</h1>
+            <p class="text-lg text-gray-100">Ce qui se passe maintenant et juste après 👇</p>
+        </div>
+
+        <!-- ============ POST ============ -->
+        <div data-when="post">
+            <div class="text-6xl mb-4" aria-hidden="true">🦙</div>
+            <h1 class="text-4xl sm:text-5xl font-black mb-4">Merci à tous pour ce super événement !</h1>
+            <p class="text-lg text-gray-100 mb-6">
+                Rendez-vous l'année prochaine. En attendant, revivez le programme ci-dessous.
+            </p>
+            <a href="/schedule" class="btn btn-primary inline-flex items-center gap-2">📅 Voir le programme</a>
+        </div>
+    </div>
+</section>
+
+<style is:global>
+    /* Inverse de data-eventday-only : masqué le jour J. */
+    html[data-eventday='true'] [data-eventday-hide] {
+        display: none !important;
+    }
+</style>
+
+<script>
+    // Compte à rebours jusqu'à la première conférence (phase preevent, hors jour J).
+    function tickCountdown() {
+        const el = document.getElementById('countdown')
+        if (!el) return
+        const target = el.getAttribute('data-target')
+        if (!target) return
+        const now = (() => {
+            try {
+                const p = new URLSearchParams(window.location.search).get('now')
+                if (p) {
+                    const d = new Date(p)
+                    if (!isNaN(d.getTime())) return d
+                }
+            } catch (e) {}
+            return new Date()
+        })()
+        const diff = new Date(target).getTime() - now.getTime()
+        if (diff <= 0) {
+            el.textContent = "C'est parti !"
+            return
+        }
+        const days = Math.floor(diff / 86400000)
+        const hours = Math.floor((diff % 86400000) / 3600000)
+        const mins = Math.floor((diff % 3600000) / 60000)
+        if (days >= 1) {
+            el.textContent = `Plus que ${days} jour${days > 1 ? 's' : ''} et ${hours} h`
+        } else {
+            el.textContent = `Plus que ${hours} h ${mins.toString().padStart(2, '0')} min`
+        }
+    }
+    tickCountdown()
+    setInterval(tickCountdown, 30000)
+    document.addEventListener('astro:after-swap', tickCountdown)
+</script>

--- a/src/components/home/HomePhaseHero.astro
+++ b/src/components/home/HomePhaseHero.astro
@@ -17,22 +17,52 @@ const venue = EVENT_DATA.event.location.venue
 const city = EVENT_DATA.event.location.city
 ---
 
-<section class="hero-gradient relative overflow-hidden pt-28 pb-16 sm:pt-32 sm:pb-20 text-white">
+<section class="hero-gradient relative overflow-hidden pt-32 pb-20 sm:pt-36 sm:pb-28 text-white">
     <div class="absolute -top-24 -right-24 w-72 h-72 bg-secondary-500/20 rounded-full blur-3xl" aria-hidden="true">
     </div>
     <div class="absolute -bottom-24 -left-24 w-72 h-72 bg-primary-400/20 rounded-full blur-3xl" aria-hidden="true">
     </div>
 
-    <div class="relative max-w-3xl mx-auto px-5 text-center">
+    {/* Particules flottantes décoratives (cohérence avec le hero principal). */}
+    <div class="absolute inset-0 overflow-hidden pointer-events-none" aria-hidden="true">
+        <div
+            class="absolute top-16 left-6 sm:left-16 w-3 h-3 bg-white/10 rounded-full animate-float"
+            style="animation-delay: 0s;">
+        </div>
+        <div
+            class="absolute top-28 right-8 sm:right-24 w-4 h-4 sm:w-6 sm:h-6 bg-secondary-300/20 rounded-full animate-float"
+            style="animation-delay: 1s;">
+        </div>
+        <div
+            class="absolute bottom-20 left-10 sm:left-28 w-2 h-2 sm:w-3 sm:h-3 bg-primary-300/20 rounded-full animate-float"
+            style="animation-delay: 2s;">
+        </div>
+        <div
+            class="hidden sm:block absolute top-1/2 right-1/3 w-4 h-4 bg-white/5 rounded-full animate-float"
+            style="animation-delay: 0.5s;">
+        </div>
+    </div>
+
+    {/* Motif radial animé (décoratif). */}
+    <div class="absolute inset-0 opacity-20 pointer-events-none" aria-hidden="true">
+        <div
+            class="absolute inset-0 animate-gradient"
+            style="background-image: radial-gradient(circle at 25% 25%, rgba(255,255,255,0.12) 1px, transparent 1px); background-size: 50px 50px;">
+        </div>
+    </div>
+
+    <div class="relative z-10 max-w-3xl mx-auto px-5 text-center">
         <!-- ============ PRE-EVENT ============ -->
         <div data-when="preevent">
             <!-- Variante jour J -->
             <div data-eventday-only>
                 <span
-                    class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-white/15 border border-white/25 text-sm font-semibold mb-5">
-                    🎉 C'est aujourd'hui !
+                    class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-white/15 backdrop-blur-sm border border-white/25 text-sm font-semibold mb-6">
+                    <span class="animate-bounce-gentle" aria-hidden="true">🎉</span> C'est aujourd'hui !
                 </span>
-                <h1 class="text-4xl sm:text-5xl font-black mb-4">Bienvenue à {EVENT_DATA.event.shortName}</h1>
+                <h1 class="text-4xl sm:text-6xl font-black text-white mb-4">
+                    Bienvenue à <span class="text-gradient">{EVENT_DATA.event.shortName}</span>
+                </h1>
                 <p class="text-lg text-gray-100 mb-2">On vous attend à <strong>{venue}</strong>, {city}.</p>
                 <p class="text-primary-100">La première conférence approche — voici comment nous rejoindre 👇</p>
             </div>
@@ -40,11 +70,18 @@ const city = EVENT_DATA.event.location.city
             <!-- Variante J-x (avant le jour J) -->
             <div data-eventday-hide>
                 <span
-                    class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-white/15 border border-white/25 text-sm font-semibold mb-5">
-                    🗓️ {dateFull}
+                    class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-white/15 backdrop-blur-sm border border-white/25 text-sm font-semibold mb-6">
+                    <span class="animate-bounce-gentle" aria-hidden="true">🗓️</span>
+                    {dateFull}
                 </span>
-                <h1 class="text-4xl sm:text-5xl font-black mb-4">{EVENT_DATA.event.shortName}, c'est bientôt !</h1>
-                <p id="countdown" class="text-2xl sm:text-3xl font-bold text-primary-100 mb-3" data-target={liveStart}>
+                <h1 class="text-4xl sm:text-6xl font-black text-white mb-5">
+                    {EVENT_DATA.event.shortName}, <span class="text-gradient">c'est bientôt</span> !
+                </h1>
+                <p
+                    id="countdown"
+                    class="text-3xl sm:text-4xl font-black text-white mb-4"
+                    data-target={liveStart}
+                    data-event-day={EVENT_DATA.event.date.iso}>
                     &nbsp;
                 </p>
                 <p class="text-gray-100">Préparez votre venue à <strong>{venue}</strong>, {city}.</p>
@@ -54,17 +91,22 @@ const city = EVENT_DATA.event.location.city
         <!-- ============ LIVE ============ -->
         <div data-when="live">
             <span
-                class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-red-500/90 text-sm font-bold mb-5 animate-pulse">
+                class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-red-500/90 text-sm font-bold mb-6 animate-pulse">
                 🔴 En direct
             </span>
-            <h1 class="text-4xl sm:text-5xl font-black mb-4">{EVENT_DATA.event.shortName} en cours</h1>
+            <h1 class="text-4xl sm:text-6xl font-black text-white mb-4">
+                {EVENT_DATA.event.shortName}
+                <span class="text-gradient">en cours</span>
+            </h1>
             <p class="text-lg text-gray-100">Ce qui se passe maintenant et juste après 👇</p>
         </div>
 
         <!-- ============ POST ============ -->
         <div data-when="post">
             <div class="text-6xl mb-4" aria-hidden="true">🦙</div>
-            <h1 class="text-4xl sm:text-5xl font-black mb-4">Merci à tous pour ce super événement !</h1>
+            <h1 class="text-4xl sm:text-6xl font-black text-white mb-4">
+                Merci à tous pour ce <span class="text-gradient">super événement</span> !
+            </h1>
             <p class="text-lg text-gray-100 mb-6">
                 Rendez-vous l'année prochaine. En attendant, revivez le programme ci-dessous.
             </p>
@@ -102,12 +144,24 @@ const city = EVENT_DATA.event.location.city
             el.textContent = "C'est parti !"
             return
         }
-        const days = Math.floor(diff / 86400000)
-        const hours = Math.floor((diff % 86400000) / 3600000)
-        const mins = Math.floor((diff % 3600000) / 60000)
-        if (days >= 1) {
-            el.textContent = `Plus que ${days} jour${days > 1 ? 's' : ''} et ${hours} h`
+        // Écart en jours calendaires (pas en multiples de 24 h) entre aujourd'hui et
+        // le jour J : ainsi le 17 au soir affiche bien "demain" et non "dans 0 jour".
+        const eventDayAttr = el.getAttribute('data-event-day')
+        let calDays = null
+        if (eventDayAttr) {
+            const [y, m, d] = eventDayAttr.split('-').map(Number)
+            const eventMidnight = new Date(y, m - 1, d)
+            const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+            calDays = Math.round((eventMidnight.getTime() - todayMidnight.getTime()) / 86400000)
+        }
+        if (calDays === 1) {
+            el.textContent = "C'est demain !"
+        } else if (calDays !== null && calDays >= 2) {
+            el.textContent = `Plus que ${calDays} jours`
         } else {
+            // Jour J (ou repli) : compte à rebours en heures/minutes.
+            const hours = Math.floor(diff / 3600000)
+            const mins = Math.floor((diff % 3600000) / 60000)
             el.textContent = `Plus que ${hours} h ${mins.toString().padStart(2, '0')} min`
         }
     }

--- a/src/components/home/HomePhaseHero.astro
+++ b/src/components/home/HomePhaseHero.astro
@@ -2,6 +2,8 @@
 // Hero léger, affiché dans les phases preevent / live / post (le hero marketing
 // reste réservé à la phase default). Chaque variante est gatée par data-when ;
 // la variante "jour J" utilise data-eventday-only. Pas d'image lourde ici.
+import { Picture } from 'astro:assets'
+import backgroundHome from '../../assets/hero.webp'
 import { EVENT_DATA } from '../../config'
 import { getScheduleData } from '../../data/conference-hall'
 
@@ -31,6 +33,26 @@ const city = EVENT_DATA.event.location.city
 ---
 
 <section class="hero-gradient relative overflow-hidden pt-32 pb-20 sm:pt-36 sm:pb-28 text-white">
+    {/* Fond lama (même asset que le hero marketing, déjà préchargé) + voile dégradé pour la lisibilité. */}
+    <Picture
+        src={backgroundHome}
+        formats={['avif', 'webp']}
+        widths={[480, 768, 1024, 1280, 1600]}
+        alt=""
+        loading="lazy"
+        decoding="async"
+        sizes="100vw"
+        width={backgroundHome.width}
+        height={backgroundHome.height}
+        class="absolute inset-0 w-full h-full object-cover opacity-60 pointer-events-none"
+        style="z-index:0;"
+    />
+    <div
+        class="absolute inset-0 bg-gradient-to-br from-primary-900/90 via-primary-800/80 to-secondary-900/90 animate-gradient pointer-events-none"
+        style="z-index:1;"
+        aria-hidden="true">
+    </div>
+
     <div class="absolute -top-24 -right-24 w-72 h-72 bg-secondary-500/20 rounded-full blur-3xl" aria-hidden="true">
     </div>
     <div class="absolute -bottom-24 -left-24 w-72 h-72 bg-primary-400/20 rounded-full blur-3xl" aria-hidden="true">

--- a/src/components/home/HomePhaseHero.astro
+++ b/src/components/home/HomePhaseHero.astro
@@ -21,6 +21,9 @@ const doorsTime = doorsIso
           return `${parseInt(h, 10)}h${min === '00' ? '' : min}`
       })()
     : null
+// Suffixe construit en une seule string : évite qu'un point isolé en JSX hérite
+// d'un espace parasite après reformatage prettier.
+const doorsSuffix = doorsTime ? ` — ouverture des portes à partir de ${doorsTime}.` : '.'
 
 const dateFull = EVENT_DATA.event.date.full
 const venue = EVENT_DATA.event.location.venue
@@ -93,16 +96,7 @@ const city = EVENT_DATA.event.location.city
                         data-event-day={EVENT_DATA.event.date.iso}>c'est bientôt</span
                     > !
                 </h1>
-                <p class="text-lg text-gray-100">
-                    <strong>{venue}</strong>, {city}{
-                        doorsTime && (
-                            <Fragment>
-                                {' '}
-                                — ouverture des portes à partir de <strong>{doorsTime}</strong>
-                            </Fragment>
-                        )
-                    }.
-                </p>
+                <p class="text-lg text-gray-100"><strong>{venue}</strong>, {city}{doorsSuffix}</p>
             </div>
         </div>
 

--- a/src/components/home/HomePhaseHero.astro
+++ b/src/components/home/HomePhaseHero.astro
@@ -75,16 +75,15 @@ const city = EVENT_DATA.event.location.city
                     {dateFull}
                 </span>
                 <h1 class="text-4xl sm:text-6xl font-black text-white mb-5">
-                    {EVENT_DATA.event.shortName}, <span class="text-gradient">c'est bientôt</span> !
+                    {EVENT_DATA.event.shortName},{' '}
+                    <span
+                        id="countdown"
+                        class="text-gradient"
+                        data-target={liveStart}
+                        data-event-day={EVENT_DATA.event.date.iso}>c'est bientôt</span
+                    > !
                 </h1>
-                <p
-                    id="countdown"
-                    class="text-3xl sm:text-4xl font-black text-white mb-4"
-                    data-target={liveStart}
-                    data-event-day={EVENT_DATA.event.date.iso}>
-                    &nbsp;
-                </p>
-                <p class="text-gray-100">Préparez votre venue à <strong>{venue}</strong>, {city}.</p>
+                <p class="text-lg text-gray-100">Préparez votre venue à <strong>{venue}</strong>, {city}.</p>
             </div>
         </div>
 
@@ -140,8 +139,9 @@ const city = EVENT_DATA.event.location.city
             return new Date()
         })()
         const diff = new Date(target).getTime() - now.getTime()
+        // Le texte s'insère dans le titre : "Tech'Work, <countdown> !".
         if (diff <= 0) {
-            el.textContent = "C'est parti !"
+            el.textContent = "c'est parti"
             return
         }
         // Écart en jours calendaires (pas en multiples de 24 h) entre aujourd'hui et
@@ -155,14 +155,11 @@ const city = EVENT_DATA.event.location.city
             calDays = Math.round((eventMidnight.getTime() - todayMidnight.getTime()) / 86400000)
         }
         if (calDays === 1) {
-            el.textContent = "C'est demain !"
+            el.textContent = "c'est demain"
         } else if (calDays !== null && calDays >= 2) {
-            el.textContent = `Plus que ${calDays} jours`
+            el.textContent = `c'est dans ${calDays} jours`
         } else {
-            // Jour J (ou repli) : compte à rebours en heures/minutes.
-            const hours = Math.floor(diff / 3600000)
-            const mins = Math.floor((diff % 3600000) / 60000)
-            el.textContent = `Plus que ${hours} h ${mins.toString().padStart(2, '0')} min`
+            el.textContent = "c'est bientôt"
         }
     }
     tickCountdown()

--- a/src/components/home/HomePracticalSummary.astro
+++ b/src/components/home/HomePracticalSummary.astro
@@ -1,0 +1,50 @@
+---
+// Phase preevent : l'essentiel pour venir, sans dupliquer /location.
+// Résumé court (adresse, horaire, accès) + boutons vers /location et /schedule.
+import { EVENT_DATA } from '../../config'
+
+const { location, duration, date } = EVENT_DATA.event
+const access = [
+    { icon: '🚇', label: 'Métro A — arrêt Perrache (5 min à pied)' },
+    { icon: '🚊', label: 'Tram T1 & T2 — Perrache' },
+    { icon: '🅿️', label: 'Q-Park Lyon Perrache Archives (en face)' },
+    { icon: '🚲', label: "Station Vélo'v Place des Archives" },
+]
+---
+
+<section class="py-12 sm:py-16 bg-gray-50">
+    <div class="max-w-3xl mx-auto px-5">
+        <div class="text-center mb-8">
+            <h2 class="text-2xl sm:text-3xl font-black text-gray-900 mb-2">Comment venir</h2>
+            <p class="text-gray-600">{date.full} — ouverture des portes à {duration.startTime}</p>
+        </div>
+
+        <div class="card p-6 sm:p-8">
+            <div class="flex items-start gap-3 mb-5">
+                <span class="text-2xl" aria-hidden="true">📍</span>
+                <div>
+                    <p class="font-bold text-gray-900">{location.venue}</p>
+                    <p class="text-gray-600">{location.address}</p>
+                </div>
+            </div>
+
+            <ul class="grid sm:grid-cols-2 gap-3 mb-6">
+                {
+                    access.map((a) => (
+                        <li class="flex items-center gap-2.5 text-sm text-gray-700">
+                            <span class="text-lg" aria-hidden="true">
+                                {a.icon}
+                            </span>
+                            <span>{a.label}</span>
+                        </li>
+                    ))
+                }
+            </ul>
+
+            <div class="flex flex-col sm:flex-row gap-3">
+                <a href="/location" class="btn btn-primary flex-1 justify-center">🗺️ Itinéraire & plan d'accès</a>
+                <a href="/schedule" class="btn btn-secondary flex-1 justify-center">📅 Voir le programme</a>
+            </div>
+        </div>
+    </div>
+</section>

--- a/src/components/home/HomePracticalSummary.astro
+++ b/src/components/home/HomePracticalSummary.astro
@@ -2,8 +2,22 @@
 // Phase preevent : l'essentiel pour venir, sans dupliquer /location.
 // Résumé court (adresse, horaire, accès) + boutons vers /location et /schedule.
 import { EVENT_DATA } from '../../config'
+import { getScheduleData } from '../../data/conference-hall'
 
-const { location, duration, date } = EVENT_DATA.event
+const { location, date } = EVENT_DATA.event
+
+// Ouverture des portes = début de la 1ʳᵉ entrée du programme (accueil inclus),
+// pour rester cohérent avec le hero. Format FR : "8h30", "9h".
+const { sessions, commonSessions } = getScheduleData()
+const doorsIso = [...sessions.map((s) => s.dateStart), ...commonSessions.map((c) => c.dateStart)]
+    .filter((d): d is string => !!d)
+    .sort()[0]
+const doorsTime = doorsIso
+    ? (() => {
+          const [h, min] = doorsIso.slice(11, 16).split(':')
+          return `${parseInt(h, 10)}h${min === '00' ? '' : min}`
+      })()
+    : EVENT_DATA.event.duration.startTime
 const access = [
     { icon: '🚇', label: 'Métro A — arrêt Perrache (5 min à pied)' },
     { icon: '🚊', label: 'Tram T1 & T2 — Perrache' },
@@ -16,7 +30,7 @@ const access = [
     <div class="max-w-3xl mx-auto px-5">
         <div class="text-center mb-8">
             <h2 class="text-2xl sm:text-3xl font-black text-gray-900 mb-2">Comment venir</h2>
-            <p class="text-gray-600">{date.full} — ouverture des portes à {duration.startTime}</p>
+            <p class="text-gray-600">{date.full} — ouverture des portes à partir de {doorsTime}</p>
         </div>
 
         <div class="card p-6 sm:p-8">

--- a/src/components/home/SponsorsBlock.astro
+++ b/src/components/home/SponsorsBlock.astro
@@ -8,7 +8,11 @@ interface Props {
 
 const { sponsorCategories } = Astro.props
 
-const sponsorsCategoriesSorted = sponsorCategories.sort((a, b) => a.order - b.order)
+// On écarte les catégories sans sponsor (sinon un titre de catégorie s'affiche
+// au-dessus d'une grille vide). Si tout est vide, l'état "Devenir partenaire" prend le relais.
+const sponsorsCategoriesSorted = sponsorCategories
+    .filter((c) => Array.isArray(c.sponsors) && c.sponsors.length > 0)
+    .sort((a, b) => a.order - b.order)
 ---
 
 <section id="sponsors" class="py-12 sm:py-16 lg:py-20 bg-white">

--- a/src/components/partners/AnimationPartnersSection.astro
+++ b/src/components/partners/AnimationPartnersSection.astro
@@ -6,25 +6,32 @@ import PartnerLogoCard from './PartnerLogoCard.astro'
 const partners = (PARTNERS_DATA as unknown as PartnersConfig).animationPartners
 ---
 
-<section
-    id="animation-partners-sponsors"
-    class="py-12 sm:py-16 bg-gradient-to-br from-primary-50 via-white to-secondary-50 border-t border-primary-100"
-    aria-labelledby="animation-partners-title">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="text-center mb-10 scroll-animate">
-            <div
-                class="inline-flex items-center px-4 py-2 bg-primary-100 text-primary-700 rounded-full text-sm font-semibold mb-4">
-                <span class="mr-2" aria-hidden="true">🎨</span>
-                Animations & Artisans
-            </div>
-            <h2 id="animation-partners-title" class="text-2xl sm:text-3xl font-black text-gray-900 mb-4">
-                Animations & <span class="text-gradient">Artisans</span>
-            </h2>
-            <p class="text-base sm:text-lg text-gray-600 max-w-2xl mx-auto">Présents le 18 juin 2026.</p>
-        </div>
+{
+    partners.length > 0 && (
+        <section
+            id="animation-partners-sponsors"
+            class="py-12 sm:py-16 bg-gradient-to-br from-primary-50 via-white to-secondary-50 border-t border-primary-100"
+            aria-labelledby="animation-partners-title">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div class="text-center mb-10 scroll-animate">
+                    <div class="inline-flex items-center px-4 py-2 bg-primary-100 text-primary-700 rounded-full text-sm font-semibold mb-4">
+                        <span class="mr-2" aria-hidden="true">
+                            🎨
+                        </span>
+                        Animations & Artisans
+                    </div>
+                    <h2 id="animation-partners-title" class="text-2xl sm:text-3xl font-black text-gray-900 mb-4">
+                        Animations & <span class="text-gradient">Artisans</span>
+                    </h2>
+                    <p class="text-base sm:text-lg text-gray-600 max-w-2xl mx-auto">Présents le 18 juin 2026.</p>
+                </div>
 
-        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 stagger-children">
-            {partners.map((partner) => <PartnerLogoCard partner={partner} size="large" />)}
-        </div>
-    </div>
-</section>
+                <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 stagger-children">
+                    {partners.map((partner) => (
+                        <PartnerLogoCard partner={partner} size="large" />
+                    ))}
+                </div>
+            </div>
+        </section>
+    )
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -15,6 +15,7 @@ import eventData from './event.json'
 import menuData from './menu.json'
 import jobsData from './jobs.json'
 import partnersData from './partners.json'
+import liveData from './live.json'
 // Calcul de l'état du CFP
 const now = new Date()
 // On utilise isOpen du fichier de config qui est mis à jour par le script fetch-cfp
@@ -43,6 +44,9 @@ export const SOCIAL_DATA = socialData
 export const SERVICES_DATA = servicesData
 export const EVENT_DATA = eventData
 export const PARTNERS_DATA = partnersData
+
+// Configuration de l'accueil adaptative "live" (phases, fenêtre feedback, salles par track)
+export const LIVE_DATA = liveData
 
 // Configuration de l'équipe
 export const TEAM_CONFIG = teamData

--- a/src/config/live.json
+++ b/src/config/live.json
@@ -1,0 +1,17 @@
+{
+    "preEventStart": "2026-06-15T00:00:00",
+    "feedbackWindowMinutes": 20,
+    "wifi": {
+        "ssid": "",
+        "password": ""
+    },
+    "rooms": {
+        "Agilité": "C 254",
+        "Craft": "C 225",
+        "DevOps": "C 329",
+        "Data": "C 302",
+        "Workshop1": "C 228",
+        "Workshop2": "C 251",
+        "Commun": "Amphithéâtre (RDC)"
+    }
+}

--- a/src/data/conference-hall.ts
+++ b/src/data/conference-hall.ts
@@ -1,5 +1,6 @@
 import type { Session, Speaker, Track, Category } from '../type'
 import scheduleData from './schedule.json'
+import { LIVE_DATA } from '../config'
 
 // Conference-Hall API types
 interface CHSpeaker {
@@ -72,6 +73,15 @@ function fixTimestamp(iso: string): string {
 function normalizeTrackName(name: string): string {
     if (name.startsWith('Workshop')) return 'Workshop'
     return name
+}
+
+// Résout la salle physique depuis le nom de track BRUT de Conference Hall
+// (avant normalizeTrackName, sinon Workshop1 et Workshop2 — deux salles distinctes —
+// seraient confondus). Les placeholders "TODO" non renseignés sont traités comme absents.
+const ROOMS = LIVE_DATA.rooms as Record<string, string>
+function resolveRoom(rawTrack: string): string | null {
+    const room = ROOMS[rawTrack]
+    return room && room !== 'TODO' ? room : null
 }
 
 function inferSocialIcon(url: string): { name: string; icon: string; link: string } {
@@ -166,6 +176,7 @@ export function getScheduleData(): ScheduleResult {
             durationMinutes,
             speakerIds,
             trackId,
+            room: resolveRoom(s.track),
             language: s.language,
             level: s.proposal!.level || null,
             categoryId,

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,6 +6,7 @@ import CookieConsent from '../components/legal/CookieConsent.astro'
 import JsonLd from '../components/seo/JsonLd.astro'
 import EVENT_DATA from '../config/event.json'
 import AccessibilityPanel from '../components/accessibility/AccessibilityPanel.astro'
+import PhaseController from '../components/PhaseController.astro'
 
 import '../styles/global.css'
 
@@ -236,6 +237,7 @@ const breadcrumbListSchema =
             })()
         </script>
         <ClientRouter />
+        <PhaseController />
     </head>
     <body class="antialiased">
         <a href="#main-content" class="skip-link">Aller au contenu principal</a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,6 +15,9 @@ import HomeFAQ from '../components/home/HomeFAQ.astro'
 import HomeCommunityBlock from '../components/home/HomeCommunityBlock.astro'
 import HomePartnersBlock from '../components/home/HomePartnersBlock.astro'
 import AnimationPartnersSection from '../components/partners/AnimationPartnersSection.astro'
+import HomePhaseHero from '../components/home/HomePhaseHero.astro'
+import HomePracticalSummary from '../components/home/HomePracticalSummary.astro'
+import HomeLiveSessions from '../components/home/HomeLiveSessions.astro'
 
 const response = await fetch(OPENPLANNER_URL)
 const openPlannerData: OpenPlannerType = await response.json()
@@ -24,16 +27,35 @@ const tickets = await getCollection('tickets')
 <Layout
     title="Tech'Work Lyon 2026"
     description="L'événement tech décalé qui crée des connexions mémorables. Talks inspirants, ateliers pratiques, artisans locaux et rencontres authentiques – ambiance lama garantie 🦙">
-    <Hero />
+    {/* Hero adaptatif (preevent / live / post) — masqué en phase default */}
+    <div data-when="preevent live post">
+        <HomePhaseHero />
+    </div>
 
-    <HomeContentBlock />
+    {/* Accueil marketing — phase default uniquement (+ fallback no-JS / SEO) */}
+    <div data-when="default">
+        <Hero />
 
-    <HomeTestimonials />
-    <HomeTicketsBlock tickets={tickets} />
-    <HomeCommunityBlock />
-    <HomeGalleryBlock />
-    <HomeFAQ />
+        <HomeContentBlock />
 
+        <HomeTestimonials />
+        <HomeTicketsBlock tickets={tickets} />
+        <HomeCommunityBlock />
+        <HomeGalleryBlock />
+        <HomeFAQ />
+    </div>
+
+    {/* Phase preevent : comment venir */}
+    <div data-when="preevent">
+        <HomePracticalSummary />
+    </div>
+
+    {/* Phase live : sessions en cours / à venir / feedback / favoris */}
+    <div data-when="live">
+        <HomeLiveSessions />
+    </div>
+
+    {/* Sponsors & partenaires — conservés dans toutes les phases */}
     <HomePartnersBlock />
     <SponsorsBlock sponsorCategories={openPlannerData.sponsors} />
     <AnimationPartnersSection />

--- a/src/pages/schedule/day-[num].astro
+++ b/src/pages/schedule/day-[num].astro
@@ -4,7 +4,7 @@ import Layout from '../../layouts/Layout.astro'
 import ScheduleSessionCard from '../../components/schedule/ScheduleSessionCard.astro'
 import UserSchedule from '../../components/schedule/UserSchedule.astro'
 import CTASection from '../../components/cta/CTASection.astro'
-import { EVENT_DATA } from '../../config'
+import { EVENT_DATA, LIVE_DATA } from '../../config'
 import { getScheduleData } from '../../data/conference-hall'
 
 export async function getStaticPaths() {
@@ -129,6 +129,15 @@ const GRID_COLUMNS = tracks
     }))
 
 const GRID_COLUMN_TEMPLATE = `64px ${GRID_COLUMNS.map((c) => `${c.widthFr}fr`).join(' ')}`
+
+// Salle fixe d'un track (en-tête de colonne). Le track Workshop regroupe deux
+// salles distinctes (une par session) -> pas de salle unique en en-tête : on
+// affiche alors la salle au niveau de chaque session.
+const ROOM_BY_TRACK = LIVE_DATA.rooms as Record<string, string>
+function roomForTrackName(name: string): string | null {
+    const r = ROOM_BY_TRACK[name]
+    return r && r !== 'TODO' ? r : null
+}
 
 const TRACK_SLOTS = [
     { start: '10:00', end: '10:50' },
@@ -346,7 +355,10 @@ function isCellOccupied(gridRow: number, trackId: string): boolean {
                             <div
                                 class="schedule-grid-col-header"
                                 style={`grid-row: 1; grid-column: ${ci + 2}; background-color: ${col.color}`}>
-                                {col.name}
+                                <span>{col.name}</span>
+                                {roomForTrackName(col.name) && (
+                                    <span class="schedule-grid-col-room">Salle {roomForTrackName(col.name)}</span>
+                                )}
                             </div>
                         ))}
 
@@ -421,6 +433,7 @@ function isCellOccupied(gridRow: number, trackId: string): boolean {
                                             style={`grid-row: ${entry.gridRow}; grid-column: 2 / -1;`}>
                                             <div class="schedule-keynote-header">
                                                 <span class="schedule-keynote-badge">Keynote</span>
+                                                {ks.room && <span class="schedule-grid-cell-room">📍 {ks.room}</span>}
                                                 <span class="schedule-grid-cell-time">
                                                     {startTime} — {endTime}
                                                     <span class="schedule-grid-cell-duration">
@@ -509,6 +522,11 @@ function isCellOccupied(gridRow: number, trackId: string): boolean {
                                                                 {result.session.durationMinutes} min
                                                             </span>
                                                         </div>
+                                                        {!roomForTrackName(col.name) && result.session.room && (
+                                                            <span class="schedule-grid-cell-room">
+                                                                📍 {result.session.room}
+                                                            </span>
+                                                        )}
                                                         <h3 class="schedule-grid-cell-title">{result.session.title}</h3>
                                                         {result.session.level && (
                                                             <span
@@ -610,6 +628,9 @@ function isCellOccupied(gridRow: number, trackId: string): boolean {
                                                     style="background-color: #6366f1">
                                                     Keynote
                                                 </span>
+                                                {ks.room && (
+                                                    <span class="schedule-mobile-session-room">📍 {ks.room}</span>
+                                                )}
                                                 <span class="schedule-mobile-session-duration">
                                                     {ks.durationMinutes} min
                                                 </span>
@@ -664,6 +685,9 @@ function isCellOccupied(gridRow: number, trackId: string): boolean {
                                                     style={`background-color: ${col.color}`}>
                                                     {col.name}
                                                 </span>
+                                                {s.room && (
+                                                    <span class="schedule-mobile-session-room">📍 {s.room}</span>
+                                                )}
                                                 <span class="schedule-mobile-session-duration">
                                                     {s.durationMinutes} min
                                                 </span>
@@ -764,9 +788,10 @@ function isCellOccupied(gridRow: number, trackId: string): boolean {
 
     .schedule-grid-col-header {
         display: flex;
+        flex-direction: column;
         align-items: center;
         justify-content: center;
-        gap: 6px;
+        gap: 2px;
         padding: 10px 8px;
         border-radius: 12px;
         color: white;
@@ -774,6 +799,25 @@ function isCellOccupied(gridRow: number, trackId: string): boolean {
         font-size: 0.8rem;
         text-align: center;
         white-space: nowrap;
+    }
+
+    .schedule-grid-col-room {
+        font-size: 0.7rem;
+        font-weight: 600;
+        opacity: 0.85;
+        letter-spacing: 0.02em;
+    }
+
+    .schedule-grid-cell-room {
+        display: inline-block;
+        align-self: flex-start;
+        font-size: 0.68rem;
+        font-weight: 700;
+        color: #374151;
+        background: #f3f4f6;
+        border-radius: 9999px;
+        padding: 1px 8px;
+        margin: 2px 0;
     }
 
     .schedule-grid-time {
@@ -1084,6 +1128,16 @@ function isCellOccupied(gridRow: number, trackId: string): boolean {
             font-size: 0.65rem;
             font-weight: 600;
             color: white;
+            padding: 2px 8px;
+            border-radius: 6px;
+            white-space: nowrap;
+        }
+
+        .schedule-mobile-session-room {
+            font-size: 0.65rem;
+            font-weight: 700;
+            color: #374151;
+            background: #f3f4f6;
             padding: 2px 8px;
             border-radius: 6px;
             white-space: nowrap;

--- a/src/pages/sessions/[...slug].astro
+++ b/src/pages/sessions/[...slug].astro
@@ -87,6 +87,8 @@ const feedbackUrl = getFeedbackUrl({ sessionId: id, dateStart: dateStart ?? '', 
                 <!-- Back link -->
                 <a
                     href={parentUrl}
+                    data-back-link
+                    data-default-href={parentUrl}
                     class="inline-flex items-center text-white/70 hover:text-white transition-colors mb-8 text-sm">
                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path
@@ -95,7 +97,7 @@ const feedbackUrl = getFeedbackUrl({ sessionId: id, dateStart: dateStart ?? '', 
                             stroke-width="2"
                             d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
                     </svg>
-                    Retour au programme
+                    <span data-back-label>Retour au programme</span>
                 </a>
 
                 <!-- Badges -->
@@ -275,11 +277,40 @@ const feedbackUrl = getFeedbackUrl({ sessionId: id, dateStart: dateStart ?? '', 
     <section class="py-12 bg-gradient-to-br from-gray-50 to-white">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <div class="scroll-animate">
-                <a href={parentUrl} class="btn btn-primary text-lg px-8 py-4 hover-lift group">
-                    <span class="mr-2 group-hover:animate-bounce-gentle">📅</span>
-                    Retour au programme
+                <a
+                    href={parentUrl}
+                    data-back-link
+                    data-default-href={parentUrl}
+                    class="btn btn-primary text-lg px-8 py-4 hover-lift group">
+                    <span class="mr-2 group-hover:animate-bounce-gentle" data-back-icon>📅</span>
+                    <span data-back-label>Retour au programme</span>
                 </a>
             </div>
         </div>
     </section>
+
+    <script>
+        // Adapte le bouton "retour" si l'on arrive depuis l'accueil live (?from=live) :
+        // libellé "Retour au live" + retour navigateur pour retrouver l'onglet et la
+        // position de défilement exacts. Sinon, comportement par défaut (programme).
+        function setupBackLinks() {
+            const from = new URLSearchParams(window.location.search).get('from')
+            const links = document.querySelectorAll<HTMLAnchorElement>('[data-back-link]')
+            if (from !== 'live') return
+            links.forEach((a) => {
+                const label = a.querySelector('[data-back-label]')
+                if (label) label.textContent = 'Retour au live'
+                const icon = a.querySelector('[data-back-icon]')
+                if (icon) icon.textContent = '🔴'
+                a.setAttribute('href', '/') // repli si pas d'historique
+                a.addEventListener('click', (e) => {
+                    e.preventDefault()
+                    if (window.history.length > 1) window.history.back()
+                    else window.location.href = '/'
+                })
+            })
+        }
+        setupBackLinks()
+        document.addEventListener('astro:page-load', setupBackLinks)
+    </script>
 </Layout>

--- a/src/pages/sessions/[...slug].astro
+++ b/src/pages/sessions/[...slug].astro
@@ -298,6 +298,11 @@ const feedbackUrl = getFeedbackUrl({ sessionId: id, dateStart: dateStart ?? '', 
             const links = document.querySelectorAll<HTMLAnchorElement>('[data-back-link]')
             if (from !== 'live') return
             links.forEach((a) => {
+                // Idempotent : setupBackLinks tourne au parse ET sur astro:page-load
+                // (déclenché aussi au 1er chargement) → sans ce garde, deux listeners
+                // click feraient deux history.back() (recul de 2 pages).
+                if (a.dataset.backBound) return
+                a.dataset.backBound = '1'
                 const label = a.querySelector('[data-back-label]')
                 if (label) label.textContent = 'Retour au live'
                 const icon = a.querySelector('[data-back-icon]')

--- a/src/pages/speakers/[slug].astro
+++ b/src/pages/speakers/[slug].astro
@@ -3,17 +3,32 @@ import { Markdown } from '@astropub/md'
 import Layout from '../../layouts/Layout.astro'
 import GenericIcon from '../../components/icons/GenericIcon.astro'
 import MarkdownWrapper from '../../components/ui-elements/MarkdownWrapper.astro'
+import ScheduleSessionCard from '../../components/schedule/ScheduleSessionCard.astro'
 import { getScheduleData } from '../../data/conference-hall'
 
 export const getStaticPaths = async () => {
-    const { speakers } = getScheduleData()
+    const { speakers, sessions, tracks, categories } = getScheduleData()
 
-    return speakers.map((speaker) => ({
-        params: { slug: speaker.id },
-        props: speaker,
-    }))
+    return speakers.map((speaker) => {
+        // Sessions de ce speaker, enrichies (track / catégorie / co-speakers) pour
+        // alimenter ScheduleSessionCard et faciliter la navigation vers le talk.
+        const talks = sessions
+            .filter((s) => s.speakerIds.includes(speaker.id))
+            .map((s) => ({
+                ...s,
+                track: tracks.find((t) => t.id === s.trackId),
+                category: categories.find((c) => c.id === s.categoryId),
+                speakers: speakers.filter((sp) => s.speakerIds.includes(sp.id)),
+            }))
+
+        return {
+            params: { slug: speaker.id },
+            props: { ...speaker, talks },
+        }
+    })
 }
-const { name, company, bio, jobTitle, socials, photoUrl, geolocation, email, phone, companyLogoUrl } = Astro.props
+const { name, company, bio, jobTitle, socials, photoUrl, geolocation, email, phone, companyLogoUrl, talks } =
+    Astro.props
 ---
 
 <Layout
@@ -120,6 +135,35 @@ const { name, company, bio, jobTitle, socials, photoUrl, geolocation, email, pho
             </div>
         </div>
     </section>
+
+    <!-- Sessions du speaker -->
+    {
+        talks.length > 0 && (
+            <section class="py-12 bg-gray-50 border-y border-gray-100">
+                <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+                    <h2 class="text-2xl font-bold text-gray-900 mb-6">
+                        {talks.length > 1 ? 'Ses sessions' : 'Sa session'}
+                    </h2>
+                    <div class={`grid gap-6 ${talks.length > 1 ? 'sm:grid-cols-2' : ''}`}>
+                        {talks.map((talk, i) => (
+                            <ScheduleSessionCard
+                                id={talk.id}
+                                title={talk.title}
+                                dateStart={talk.dateStart}
+                                dateEnd={talk.dateEnd}
+                                durationMinutes={talk.durationMinutes}
+                                track={talk.track}
+                                category={talk.category}
+                                speakers={talk.speakers}
+                                level={talk.level}
+                                index={i}
+                            />
+                        ))}
+                    </div>
+                </div>
+            </section>
+        )
+    }
 
     <!-- Speaker Info -->
     <section class="py-12 sm:py-16 lg:py-20 bg-white">

--- a/src/pages/speakers/[slug].astro
+++ b/src/pages/speakers/[slug].astro
@@ -136,35 +136,6 @@ const { name, company, bio, jobTitle, socials, photoUrl, geolocation, email, pho
         </div>
     </section>
 
-    <!-- Sessions du speaker -->
-    {
-        talks.length > 0 && (
-            <section class="py-12 bg-gray-50 border-y border-gray-100">
-                <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-                    <h2 class="text-2xl font-bold text-gray-900 mb-6">
-                        {talks.length > 1 ? 'Ses sessions' : 'Sa session'}
-                    </h2>
-                    <div class={`grid gap-6 ${talks.length > 1 ? 'sm:grid-cols-2' : ''}`}>
-                        {talks.map((talk, i) => (
-                            <ScheduleSessionCard
-                                id={talk.id}
-                                title={talk.title}
-                                dateStart={talk.dateStart}
-                                dateEnd={talk.dateEnd}
-                                durationMinutes={talk.durationMinutes}
-                                track={talk.track}
-                                category={talk.category}
-                                speakers={talk.speakers}
-                                level={talk.level}
-                                index={i}
-                            />
-                        ))}
-                    </div>
-                </div>
-            </section>
-        )
-    }
-
     <!-- Speaker Info -->
     <section class="py-12 sm:py-16 lg:py-20 bg-white">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -293,6 +264,35 @@ const { name, company, bio, jobTitle, socials, photoUrl, geolocation, email, pho
             </div>
         </div>
     </section>
+
+    <!-- Sessions du speaker -->
+    {
+        talks.length > 0 && (
+            <section class="py-12 bg-gray-50 border-y border-gray-100">
+                <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+                    <h2 class="text-2xl font-bold text-gray-900 mb-6">
+                        {talks.length > 1 ? 'Ses sessions' : 'Sa session'}
+                    </h2>
+                    <div class={`grid gap-6 ${talks.length > 1 ? 'sm:grid-cols-2' : ''}`}>
+                        {talks.map((talk, i) => (
+                            <ScheduleSessionCard
+                                id={talk.id}
+                                title={talk.title}
+                                dateStart={talk.dateStart}
+                                dateEnd={talk.dateEnd}
+                                durationMinutes={talk.durationMinutes}
+                                track={talk.track}
+                                category={talk.category}
+                                speakers={talk.speakers}
+                                level={talk.level}
+                                index={i}
+                            />
+                        ))}
+                    </div>
+                </div>
+            </section>
+        )
+    }
 
     <!-- Back to Speakers -->
     <section class="py-12 bg-gradient-to-br from-gray-50 to-white">

--- a/src/type.ts
+++ b/src/type.ts
@@ -49,6 +49,7 @@ export interface Session {
     durationMinutes: number
     speakerIds: string[]
     trackId: string | null
+    room: string | null
     language: string | null
     level: string | null
     imageUrl: string | null | undefined


### PR DESCRIPTION
## Contexte

Le jour J approche : cette PR rend le site **adaptatif selon le moment de l'événement** et ajoute les outils pratiques pour les participants sur place.

## Accueil adaptatif par phase

La page d'accueil bascule automatiquement (sans intervention) selon la date/heure, dérivée du programme :

| Phase | Quand | Contenu |
|---|---|---|
| `default` | avant | site marketing habituel (billetterie, CFP…) |
| `preevent` | jours juste avant | compte à rebours « Tech'Work, c'est demain ! », comment venir, ouverture des portes |
| `live` | le jour J | programme en temps réel |
| `post` | après | message de remerciement |

- Phase calculée côté client (`PhaseController`) et posée sur `<html>` avant le paint (pas de flash). Fallback no-JS/SEO = contenu `default`.
- Prévisualisable via `?now=2026-06-18T11:00:00`.

## Mode live (jour J)

Sections temps réel, **actualisées en continu** (pas de rafraîchissement manuel) :
- Onglets **En ce moment / À venir / Tous / Favoris / Infos**
- Favoris stockés en local (par appareil)
- Feedback OpenFeedback par talk affiché à la fin de chaque session
- Onglet **Infos** : se repérer **par étage** (RDC / 2ᵉ / 3ᵉ, déduit du n° de salle), WiFi, hashtag, code de conduite, et **contacts d'urgence orga cliquables** (`tel:` réassemblés côté client depuis du base64 → pas de numéro en clair dans le HTML pour les crawlers basiques)

## Hero preevent

- Titres en `text-white` + accent `text-gradient` (ils héritaient du gris foncé global → illisibles sur le dégradé), particules animées, alignés sur le hero principal
- Countdown fusionné dans le titre : **« c'est demain »** à J-1, « c'est dans N jours » au-delà
- Sous-titre : heure d'ouverture des portes (8h30) dérivée du programme, cohérente avec « Comment venir »

## Profil speaker

- Bloc **« Sa session »** sous le profil, réutilisant `ScheduleSessionCard`, avec lien direct vers le talk

## À compléter avant mise en ligne

- [ ] SSID + mot de passe WiFi dans `src/config/live.json`
- [ ] Valider le hashtag officiel (`#QueLeLamaSoitAvecNous`)

## Tests

- `astro check` : 0 erreur
- `npm run build` : OK (90 pages)
