### PR TITLE
fix(live): activer la phase live dès l'accueil

### DIFF
--- a/src/components/PhaseController.astro
+++ b/src/components/PhaseController.astro
@@ -9,18 +9,21 @@
 //   live     -> liveStart .. liveEnd            (sessions en cours / à venir, favoris, feedback)
 //   post     -> après liveEnd                   (merci + programme)
 //
-// Les bornes liveStart / liveEnd sont DÉRIVÉES du programme (1ʳᵉ session avec
-// orateur -> dernière fin), pas codées en dur. preEventStart est une ancre de config.
+// Les bornes liveStart / liveEnd sont DÉRIVÉES du programme (début du tout premier
+// créneau du jour -> dernière fin), pas codées en dur. On inclut les créneaux "Commun"
+// (accueil, intro, pauses) pour que le mode live couvre la journée dès l'accueil, pas
+// seulement à partir de la 1ʳᵉ session avec orateur. preEventStart est une ancre de config.
 import { EVENT_DATA, LIVE_DATA } from '../config'
 import { getScheduleData } from '../data/conference-hall'
 
-const { sessions } = getScheduleData()
+const { sessions, commonSessions } = getScheduleData()
+const scheduleItems = [...sessions, ...commonSessions]
 
-const startTimes = sessions
+const startTimes = scheduleItems
     .map((s) => s.dateStart)
     .filter((d): d is string => !!d)
     .sort()
-const endTimes = sessions
+const endTimes = scheduleItems
     .map((s) => s.dateEnd)
     .filter((d): d is string => !!d)
     .sort()


### PR DESCRIPTION
## Problème (constaté le jour J)

Le matin de l'évènement, le **mode live ne s'activait pas automatiquement** : `HomeLiveSessions` restait masqué pendant l'accueil.

## Cause

Dans `PhaseController.astro`, la phase `live` démarre à `liveStart`, dérivé du programme. Mais `liveStart` était calculé sur les seules `sessions` (talks + keynotes), **excluant les créneaux « Commun »** (Accueil 08:30, Introduction 09:00). Résultat : `liveStart` = 1ʳᵉ keynote à **09:10**.

Pendant tout l'accueil (08:30–09:10), `now < liveStart` → phase `preevent`, donc mode live éteint au moment précis où les participants arrivent et veulent le programme.

## Correctif

Inclure les `commonSessions` dans le calcul des bornes :

```ts
const { sessions, commonSessions } = getScheduleData()
const scheduleItems = [...sessions, ...commonSessions]
```

`liveStart` devient **08:30** (accueil) et `liveEnd` reste la dernière fin (19:00). Le mode live couvre désormais la journée dès l'accueil.

## Vérification
- `astro check` : 0 erreur.
- Bornes recalculées : liveStart 08:30 / liveEnd 19:00.

## ⚠️ Déploiement
`liveStart`/`liveEnd` sont injectés **au build** (`define:vars`). **Un rebuild + redéploiement est nécessaire** pour que le correctif s'applique en prod aujourd'hui.